### PR TITLE
Use mempool space

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@
 `gun` is a CLI Bitcoin wallet for plebs, degenerates and revolutionaries.
 Its distinguishing features is the ability to do [peer-to-peer betting](./docs/bet.md).
 
-** ⚠ WARNING EXPERIMENTAL **
+**⚠ WARNING EXPERIMENTAL**
 
 The wallet is alpha quality.
 It is buggy and is missing features.
@@ -27,6 +27,26 @@ cargo install --path .
 cargo -Z avoid-dev-deps install --features=nightly --path .
 # Make sure ~/.cargo/bin is in your $PATH
 ```
+
+
+## Configuration
+
+The configuration file is in `~/.gun/config.json`.
+
+By default `gun init` sets [mempool.space](https://mempool.space) as the backend.
+You could choose blockstream's esplora server by setting `blockchain` to:
+
+``` sh
+{
+  "type": "esplora",
+  "base_url": "https://blockstream.info/api",
+  "concurrency": 4,
+  "stop_gap": 10
+}
+```
+
+You could also run your own [esplora](https://github.com/Blockstream/esplora) server.
+
 ## Basic Wallet
 
 The cli is decently documented with `--help` but here's a few things to get you started:

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,22 +34,22 @@ impl Config {
         let concurrency = Some(4);
         let blockchain = match network {
             Bitcoin => AnyBlockchainConfig::Esplora(EsploraBlockchainConfig {
-                base_url: "https://blockstream.info/api".to_string(),
+                base_url: "https://mempool.space/api".to_string(),
                 concurrency,
                 stop_gap: 10,
-                kind: EsploraKind::Esplora,
+                kind: EsploraKind::Mempool,
             }),
             Testnet => AnyBlockchainConfig::Esplora(EsploraBlockchainConfig {
                 base_url: "https://blockstream.info/testnet/api".to_string(),
                 concurrency,
                 stop_gap: 10,
-                kind: EsploraKind::Esplora,
+                kind: EsploraKind::default(),
             }),
             Regtest => AnyBlockchainConfig::Esplora(EsploraBlockchainConfig {
                 base_url: "http://localhost:3000".to_string(),
                 concurrency,
                 stop_gap: 10,
-                kind: EsploraKind::Esplora,
+                kind: EsploraKind::default(),
             }),
             Signet => unimplemented!("signet not supported yet!"),
         };


### PR DESCRIPTION
I added a minor change to the esplora backend to make it work for `mempool.space`. This uses it as the default. It seems to be more reliable.