### PR TITLE
Put public key first in proposal serialization

### DIFF
--- a/src/party/proposal.rs
+++ b/src/party/proposal.rs
@@ -16,7 +16,7 @@ use olivia_secp256k1::{
 
 use super::BetArgs;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum VersionedProposal {
     One(Proposal),
 }
@@ -270,5 +270,35 @@ mod test {
         let encoded = proposal.clone().into_versioned().to_string();
         let decoded = VersionedProposal::from_str(&encoded).unwrap();
         assert_eq!(proposal, decoded.into());
+    }
+
+    #[test]
+    fn to_and_from_string_fixed() {
+        // so we don't accidentally break parsing
+        use bdk::bitcoin::Address;
+        use std::str::FromStr;
+        let fixed = VersionedProposal::One(Proposal {
+            oracle: "h00.ooo".into(),
+            event_id: EventId::from_str("/EPL/match/2021-08-22/ARS_CHE.vs=CHE_win").unwrap(),
+            value: Amount::from_str("0.01000000 BTC").unwrap(),
+            inputs: vec![OutPoint::from_str(
+                "d407fe2bd55b6076ce4c78028dc95b4097dd1e5acbf6ccaa741559a0903f1565:1",
+            )
+            .unwrap()],
+            public_key: Point::from_str(
+                "119cfc5a4dd8cffeebe9cfb1b42ef3d46d2dc38decebc67826d33ec8d44030c0",
+            )
+            .unwrap(),
+            change_script: Some(
+                Address::from_str("bc1qvkswtx2t4y8t6237q753htu4hl4mxm5a9swfjw")
+                    .unwrap()
+                    .script_pubkey()
+                    .into(),
+            ),
+        });
+
+        let string =  "📣0.01#h00.ooo#/EPL/match/2021-08-22/ARS_CHE.vs=CHE_win#ǔ༖ǼभݸჷતϧષগழਞഹเϕॐಋచଚڮݻɈపŉɋʍҞɒŴݦസӫၒӵݎஜؽͼɹঊڄՓॠఖஷߣၦაŐƍۂʎӯسՉهƽཀލǂޞඤӖყଋم༎";
+        assert_eq!(VersionedProposal::from_str(string).unwrap(), fixed);
+        assert_eq!(fixed.to_string(), string);
     }
 }

--- a/src/party/proposal.rs
+++ b/src/party/proposal.rs
@@ -66,8 +66,8 @@ pub struct LocalProposal {
 
 #[derive(Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Payload {
-    pub inputs: Vec<bdk::bitcoin::OutPoint>,
     pub public_key: Point<EvenY>,
+    pub inputs: Vec<bdk::bitcoin::OutPoint>,
     pub change_script: Option<BinScript>,
 }
 


### PR DESCRIPTION
To be consistent and it allows us to read the first 32 bytes of a string and get a public key out of it even if we don't care about the message.