### PR TITLE
Split coins into evenly valued utxos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "0BSD"
 
 [dependencies]
 dirs = "3.0"
-bdk = { git = "https://github.com/llfourn/bdk", rev = "f6c81a321bcc0214cce543ebc4dc23ba119efba6", features = ["key-value-db", "esplora", "compiler", "keys-bip39"], default-features = false  }
+bdk = { git = "https://github.com/llfourn/bdk", rev = "fc08b115b98c20e33cf9182737128970ac86092f", features = ["key-value-db", "esplora", "compiler", "keys-bip39"], default-features = false  }
 # bdk = { path = "../bdk", features = ["key-value-db", "esplora", "compiler", "keys-bip39"], default-features = false }
 serde_json = "1.0"
 olivia_core = { git = "https://github.com/llfourn/olivia", rev = "04eb811239c89436b03df365998c19a6ca1ab9e6" }
@@ -34,5 +34,5 @@ nightly = ["olivia_secp256k1/nightly"]
 
 [dev-dependencies]
 rand = "0.8"
-bdk = { git = "https://github.com/llfourn/bdk", rev = "f6c81a321bcc0214cce543ebc4dc23ba119efba6", features = ["key-value-db", "esplora", "compiler", "keys-bip39", "test-esplora", "test-blockchains"], default-features = false  }
+bdk = { git = "https://github.com/llfourn/bdk", rev = "fc08b115b98c20e33cf9182737128970ac86092f", features = ["key-value-db", "esplora", "compiler", "keys-bip39", "test-esplora", "test-blockchains"], default-features = false  }
 # bdk = { path = "../bdk", features = ["key-value-db", "esplora", "compiler", "keys-bip39", "test-esplora", "test-blockchains"], default-features = false }

--- a/src/bin/gun.rs
+++ b/src/bin/gun.rs
@@ -86,7 +86,9 @@ fn main() -> anyhow::Result<()> {
             } else if opt.tabs {
                 println!("{}", output.render_simple())
             } else {
-                println!("{}", output.render())
+                if let Some(output) = output.render() {
+                    println!("{}", output)
+                }
             }
         }
         Err(e) => {

--- a/src/bin/gun.rs
+++ b/src/bin/gun.rs
@@ -1,4 +1,6 @@
-use gun_wallet::cmd::{self, bet::BetOpt, AddressOpt, InitOpt, SendOpt, TransactionOpt, UtxoOpt};
+use gun_wallet::cmd::{
+    self, bet::BetOpt, AddressOpt, InitOpt, SendOpt, SplitOpt, TransactionOpt, UtxoOpt,
+};
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -37,6 +39,8 @@ pub enum Commands {
     Send(SendOpt),
     /// Initialize a wallet
     Init(InitOpt),
+    /// Split coins into evenly sized outputs.
+    Split(SplitOpt),
 }
 
 fn main() -> anyhow::Result<()> {
@@ -74,6 +78,7 @@ fn main() -> anyhow::Result<()> {
         Commands::Init(opt) => cmd::run_init(&wallet_dir, opt),
         Commands::Tx(opt) => cmd::run_transaction_cmd(&wallet_dir, opt),
         Commands::Utxo(opt) => cmd::run_utxo_cmd(&wallet_dir, opt),
+        Commands::Split(opt) => cmd::run_split_cmd(&wallet_dir, opt),
     };
 
     match res {

--- a/src/cmd/bet.rs
+++ b/src/cmd/bet.rs
@@ -229,8 +229,11 @@ pub fn run_bet_cmd(
             }
             question += " Ok?";
             if yes || read_answer(&question) {
-                let (_bet_id, proposal) =
-                    party.make_proposal(oracle_id, oracle_event, args.into())?;
+                let local_proposal = party.make_proposal(oracle_id, oracle_event, args.into())?;
+                let proposal_string = local_proposal.proposal.clone().into_versioned().to_string();
+                let bet_id = party
+                    .bet_db()
+                    .insert_bet(BetState::Proposed { local_proposal })?;
                 eprintln!("post your proposal and let people make offers to it:");
                 Ok(item! { "proposal" => Cell::String(proposal.into_versioned().to_string()) })
             } else {

--- a/src/party/mod.rs
+++ b/src/party/mod.rs
@@ -33,7 +33,6 @@ use bdk::{
     wallet::{AddressIndex, Wallet},
     KeychainKind, SignOptions,
 };
-
 use olivia_core::{Attestation, Outcome};
 use olivia_secp256k1::{
     fun::{g, marker::*, s, Scalar, G},

--- a/src/party/proposal.rs
+++ b/src/party/proposal.rs
@@ -1,5 +1,4 @@
 use crate::{
-    bet_database::{BetId, BetState},
     bitcoin::{Amount, Script},
     change::{BinScript, Change},
     party::Party,
@@ -145,7 +144,7 @@ impl<D: BatchDatabase> Party<bdk::blockchain::EsploraBlockchain, D> {
         oracle_id: OracleId,
         oracle_event: OracleEvent<Secp256k1>,
         args: BetArgs,
-    ) -> anyhow::Result<(BetId, Proposal)> {
+    ) -> anyhow::Result<LocalProposal> {
         let event_id = &oracle_event.event.id;
         if !event_id.n_outcomes() == 2 {
             return Err(anyhow!(
@@ -229,10 +228,7 @@ impl<D: BatchDatabase> Party<bdk::blockchain::EsploraBlockchain, D> {
             tags: args.tags,
         };
 
-        let new_bet = BetState::Proposed { local_proposal };
-        let bet_id = self.bet_db.insert_bet(new_bet)?;
-
-        Ok((bet_id, proposal))
+        Ok(local_proposal)
     }
 }
 


### PR DESCRIPTION
This adds the `gun split` sub-command so you can easily spend into a bunch of smaller utxos so that your bets don't need change outputs. 