### PR TITLE
Check that all inputs are p2wpkh

### DIFF
--- a/src/party/mod.rs
+++ b/src/party/mod.rs
@@ -296,7 +296,9 @@ where
             }))
     }
 
-    pub fn outpoint_to_psbt_input(&self, outpoint: OutPoint) -> anyhow::Result<psbt::Input> {
+    // the reason we require p2wpkh inputs here is so the witness is non-malleable.
+    // What to do about TR outputs in the future I haven't decided.
+    pub fn p2wpkh_outpoint_to_psbt_input(&self, outpoint: OutPoint) -> anyhow::Result<psbt::Input> {
         let tx = self
             .wallet
             .client()
@@ -312,6 +314,10 @@ where
                 outpoint.txid
             ))?
             .clone();
+
+        if !txout.script_pubkey.is_v0_p2wpkh() {
+            return Err(anyhow!("outpoint {} was not p2wpkh"));
+        }
 
         let psbt_input = psbt::Input {
             witness_utxo: Some(txout),

--- a/src/party/offer.rs
+++ b/src/party/offer.rs
@@ -148,8 +148,8 @@ impl<D: BatchDatabase> Party<bdk::blockchain::EsploraBlockchain, D> {
         let mut input_value = 0;
         for proposal_input in &proposal.inputs {
             let psbt_input = self
-                .outpoint_to_psbt_input(*proposal_input)
-                .context("Failed to find proposal input")?;
+                .p2wpkh_outpoint_to_psbt_input(*proposal_input)
+                .context("retrieving proposal input")?;
             input_value += psbt_input.witness_utxo.as_ref().unwrap().value;
             builder.add_foreign_utxo(
                 *proposal_input,

--- a/src/party/take_offer.rs
+++ b/src/party/take_offer.rs
@@ -59,8 +59,8 @@ impl<D: BatchDatabase> Party<bdk::blockchain::EsploraBlockchain, D> {
         let mut input_value = 0;
         for input in &offer.inputs {
             let mut psbt_input = self
-                .outpoint_to_psbt_input(input.outpoint)
-                .context("Failed to find proposal input")?;
+                .p2wpkh_outpoint_to_psbt_input(input.outpoint)
+                .context("retrieving offer input")?;
             input_value += psbt_input.witness_utxo.as_ref().unwrap().value;
             psbt_input.final_script_witness = Some(input.witness.encode());
             psbt_inputs.push(psbt_input);


### PR DESCRIPTION
This is a conservative choice to stop the proposer from using inputs
that might have huge witnesses and therefore a lower feerate.