### PR TITLE
[breaking] Bump to base2048 v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,9 +62,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base2048"
-version = "0.2.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6921f5aa4622dab41300c42e51d986043f32f44b97f46b7d066f7f254e757922"
+checksum = "71f4fe417e8cc3bb9b437dfa9290ce92bd2730ba5374719bdfd9147fbc8f17cd"
 
 [[package]]
 name = "base64"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ olivia_core = { git = "https://github.com/llfourn/olivia", rev = "025cb6ad31b85d
 olivia_secp256k1 = { git = "https://github.com/llfourn/olivia", features = ["libsecp_compat"], rev = "025cb6ad31b85d3150571b902e3502a16cab88ad" }
 olivia_describe = { git = "https://github.com/llfourn/olivia", rev = "025cb6ad31b85d3150571b902e3502a16cab88ad" }
 sha2 = "0.9"
-base2048 = "0.2"
+base2048 = "2.0.2"
 chacha20 = { version = "0.7", features = ["rng", "cipher"] }
 serde = { version = "1" }
 bincode = "1.3"

--- a/src/betting/proposal.rs
+++ b/src/betting/proposal.rs
@@ -181,7 +181,8 @@ mod test {
             ),
         });
 
-        let string =  "0.01#h00.ooo#/EPL/match/2021-08-22/ARS_CHE.vs=CHE_win#ǔ༖ǼभݸჷતϧષগழਞഹเϕॐಋచଚڮݻɈపŉɋʍҞɒŴݦസӫၒӵݎஜؽͼɹঊڄՓॠఖஷߣၦაŐƍۂʎӯسՉهƽཀލǂޞඤӖყଋم༎";
+        let string =  "0.01#h00.ooo#/EPL/match/2021-08-22/ARS_CHE.vs=CHE_win#Ō࿃Ŵઝঢჰ௵ʏఒଊಫ୵ช༨ɽબവഉబ٧থǀചµǃȅАǊëঌฉѝႡѧ८ಜԺȯǱ૭զӌભഅಮਫႫႿÅąउȆѡԯӂՃĵ࿐ৠĺ৷เшრఠՁ༎";
+        dbg!(&fixed.to_string());
         assert_eq!(VersionedProposal::from_str(string).unwrap(), fixed);
         assert_eq!(fixed.to_string(), string);
     }


### PR DESCRIPTION
right-to-left encoded characters are gone from v1.0.0 so this is a big
UX improvement. This breaks existsing proposals/offers.