### PR TITLE
Add bip39 passphrase useage

### DIFF
--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -37,6 +37,13 @@ pub fn run_init(
         from_existing,
     }: InitOpt,
 ) -> anyhow::Result<CmdOutput> {
+    if wallet_dir.exists() {
+        return Err(anyhow!(
+            "wallet directory {} already exists -- delete it to create a new wallet",
+            wallet_dir.display()
+        ));
+    }
+
     let seed_words = match from_existing {
         Some(existing_words_file) => {
             let words = match existing_words_file.as_str() {
@@ -66,13 +73,6 @@ pub fn run_init(
             seed_words.phrase().into()
         }
     };
-
-    if wallet_dir.exists() {
-        return Err(anyhow!(
-            "wallet directory {} already exists -- delete it to create a new wallet",
-            wallet_dir.display()
-        ));
-    }
 
     std::fs::create_dir(&wallet_dir)?;
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -160,8 +160,19 @@ pub fn load_wallet(
                 )
             })?;
             let mut seed_bytes = [0u8; 64];
-            let seed = Seed::new(&mnemonic, "");
-            seed_bytes.copy_from_slice(seed.as_bytes());
+            match config.passphrase {
+                true => {
+                    println!("Enter bip39 passphrase : ");
+                    let mut passphrase = String::new();
+                    std::io::stdin().read_line(&mut passphrase)?;
+                    let seed = Seed::new(&mnemonic, passphrase.trim());
+                    seed_bytes.copy_from_slice(seed.as_bytes());
+                }
+                false => {
+                    let seed = Seed::new(&mnemonic, "");
+                    seed_bytes.copy_from_slice(seed.as_bytes());
+                }
+            }
             Keychain::new(seed_bytes)
         }
     };

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,7 @@ pub struct Config {
     pub blockchain: AnyBlockchainConfig,
     pub kind: WalletKind,
     pub keys: WalletKeys,
+    pub passphrase: bool,
 }
 
 impl Config {
@@ -46,6 +47,7 @@ impl Config {
             blockchain,
             kind: WalletKind::P2wpkh,
             keys: WalletKeys::SeedWordsFile,
+            passphrase: false,
         }
     }
 }


### PR DESCRIPTION
Attempt to fix https://github.com/LLFourn/gun/issues/46

Looking for approach ACKs.

Currently the seed is being generated at each `load_wallet()` call. So trying to use a passphrase forces user to input the passphrase at almost all command runs. I couldn't find a way to initialize the wallet with passphrase just for single time, at least not without significantly refactoring the internals.

So the easiest way I found was to add another config flag the determines whether or not to ask for the passphrase at `load_wallet()`. This flag will be set in `init()`. If user says it want bip39 passphrase, then they have to enter the correct passphrase for each regular commands like `address`, `balance` etc. 

There is no way to check the passphrase or fail if wrong passphrase is given, it will simply show wrong balances and addresses.   