### PR TITLE
gun init descriptor or xpub. Versioned config and secret_protocol_randomness. Save PSBTs to psbt-output-dir and wait for signing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1" }
 bincode = "1.3"
 anyhow = "1"
 thiserror = "1.0"
+rand = { version = "0.8", features = ["getrandom"] }
 structopt = "0.3"
 miniscript = { version = "6", features = ["serde"] }
 term-table = {  version = "1", default-features = false }

--- a/src/amount_ext.rs
+++ b/src/amount_ext.rs
@@ -19,7 +19,7 @@ impl FromCliStr for Amount {
 
                 Ok(Amount::from_str_in(&value, denom)?)
             }
-            None => Err(anyhow!("{} is not a Bitcoin amount")),
+            None => Err(anyhow!("'{}' is not a Bitcoin amount", string)),
         }
     }
 }

--- a/src/betting/party/mod.rs
+++ b/src/betting/party/mod.rs
@@ -298,7 +298,7 @@ where
             .clone();
 
         if !txout.script_pubkey.is_v0_p2wpkh() {
-            return Err(anyhow!("outpoint {} was not p2wpkh"));
+            return Err(anyhow!("outpoint {} was not p2wpkh", outpoint));
         }
 
         let psbt_input = psbt::Input {

--- a/src/betting/party/offer.rs
+++ b/src/betting/party/offer.rs
@@ -31,7 +31,7 @@ impl<D: BatchDatabase> Party<bdk::blockchain::EsploraBlockchain, D> {
         }
 
         let anticipated_attestations = oracle_event
-            .anticipate_attestations_olivia_v1(&oracle_info.oracle_keys.olivia_v1.ok_or(anyhow!("Oracle {} does not support olivia_v1"))?, 0)
+            .anticipate_attestations_olivia_v1(&oracle_info.oracle_keys.olivia_v1.ok_or(anyhow!("Oracle '{}' does not support olivia_v1", oracle_info.id))?, 0)
             .ok_or(anyhow!("Cannot make bet on {} since {} doesn't support olivia_v1 attestation for this event", event_id, oracle_info.id))?
             [..2]
             .try_into()

--- a/src/betting/party/state_machine.rs
+++ b/src/betting/party/state_machine.rs
@@ -30,7 +30,7 @@ where
         let bet_state = self
             .bet_db
             .get_entity(bet_id)?
-            .ok_or(anyhow!("Bet {} does not exist"))?;
+            .ok_or(anyhow!("Bet {} does not exist", bet_id))?;
         let blockchain = self.wallet.client();
 
         match bet_state {

--- a/src/betting/party/take_offer.rs
+++ b/src/betting/party/take_offer.rs
@@ -66,7 +66,7 @@ impl<D: BatchDatabase> Party<bdk::blockchain::EsploraBlockchain, D> {
         let bet_state = self
             .bet_db
             .get_entity::<BetState>(bet_id)?
-            .ok_or(anyhow!("Bet {} doesn't exist"))?;
+            .ok_or(anyhow!("Bet {} doesn't exist", bet_id))?;
         let local_proposal = match bet_state {
             BetState::Proposed { local_proposal } => local_proposal,
             _ => return Err(anyhow!("was not in proposed state")),

--- a/src/cmd/bet.rs
+++ b/src/cmd/bet.rs
@@ -640,7 +640,7 @@ pub fn run_bet_cmd(wallet_dir: &Path, cmd: BetOpt, sync: bool) -> anyhow::Result
                                     rng,
                                 ) {
                                     Ok(validated_offer) => {
-                                        let (fee, feerate) = validated_offer.bet.psbt.fee();
+                                        let (fee, feerate, _) = validated_offer.bet.psbt.fee();
                                         (Some(fee), Some(feerate), true)
                                     }
                                     Err(_) => (None, None, false),
@@ -879,7 +879,7 @@ fn bet_prompt(bet: &Bet, bet_verb: &str, you_paying_fee: bool) -> String {
         value: bet.i_chose_right as u64,
     };
 
-    let (fee, feerate) = bet.psbt.fee();
+    let (fee, feerate, _) = bet.psbt.fee();
 
     let mut table = Table::new();
     table.add_row(Row::new(vec!["event-id".into(), id.to_string()]));

--- a/src/cmd/bet.rs
+++ b/src/cmd/bet.rs
@@ -7,7 +7,7 @@ use crate::{
     psbt_ext::PsbtFeeRate,
     Url, ValueChoice,
 };
-use anyhow::*;
+use anyhow::{anyhow, Context};
 use bdk::bitcoin::{Address, Amount, Script};
 use chacha20::cipher::StreamCipher;
 use olivia_core::{chrono::Utc, Outcome, OutcomeError};

--- a/src/cmd/bet.rs
+++ b/src/cmd/bet.rs
@@ -879,7 +879,7 @@ fn bet_prompt(bet: &Bet, bet_verb: &str, you_paying_fee: bool) -> String {
         value: bet.i_chose_right as u64,
     };
 
-    let (fee, feerate, _) = bet.psbt.fee();
+    let (fee, feerate, feerate_estimated) = bet.psbt.fee();
 
     let mut table = Table::new();
     table.add_row(Row::new(vec!["event-id".into(), id.to_string()]));
@@ -894,7 +894,7 @@ fn bet_prompt(bet: &Bet, bet_verb: &str, you_paying_fee: bool) -> String {
         ),
     ]));
     table.add_row(Row::new(vec![
-        "fee".into(),
+        if feerate_estimated { "est. fee" } else { "fee" }.into(),
         format!("{} ({:.3} s/vb)", fee, feerate.as_sat_vb()),
     ]));
 

--- a/src/cmd/bet.rs
+++ b/src/cmd/bet.rs
@@ -1,7 +1,8 @@
 use super::{read_input, run_oralce_cmd, Cell};
 use crate::{
     betting::*,
-    cmd::{self, read_yn, sanitize_str, CmdOutput},
+    cmd::{self, load_config, read_yn, sanitize_str, CmdOutput},
+    config::WalletKey,
     item,
     keychain::Keychain,
     psbt_ext::PsbtFeeRate,
@@ -209,6 +210,18 @@ pub fn run_bet_cmd(wallet_dir: &Path, cmd: BetOpt, sync: bool) -> anyhow::Result
         let party = cmd::load_party(wallet_dir)?;
         party.sync()?;
         party.poke_bets();
+    }
+
+    // Betting is not yet supported for descriptor wallets
+    let config = load_config(wallet_dir).context("loading config")?;
+    if let WalletKey::Descriptor {
+        external: _,
+        internal: _,
+    } = config.wallet_key
+    {
+        return Err(anyhow!(
+            "Betting is not yet supported for descriptor based wallets."
+        ));
     }
 
     match cmd {

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -1,4 +1,7 @@
-use crate::{cmd, config::Config, item};
+use crate::{
+    cmd,
+    config::{Config, WalletKey},
+};
 use anyhow::{anyhow, Context};
 use bdk::{
     bitcoin::Network,
@@ -8,7 +11,7 @@ use bdk::{
     },
     miniscript::Segwitv0,
 };
-use cmd::Cell;
+
 use std::{fs, io, path::PathBuf, str::FromStr};
 use structopt::StructOpt;
 
@@ -17,56 +20,34 @@ use super::CmdOutput;
 pub enum NWords {}
 
 #[derive(Clone, Debug, StructOpt)]
-pub struct InitOpt {
-    /// The network name (bitcoin|regtest|testnet)
-    #[structopt(name = "bitcoin|regtest|testnet")]
-    network: Network,
-    /// Existing BIP39 seed words file. Use "-" to read words from stdin.
-    #[structopt(long, name = "FILE")]
-    from_existing: Option<String>,
-    #[structopt(long, default_value = "12", name = "[12|24]")]
-    /// The number of BIP39 seed words to use
-    n_words: usize,
+pub enum InitOpt {
+    /// Initialize a wallet using a seedphrase
+    Seed {
+        /// The network name (bitcoin|regtest|testnet)
+        #[structopt(long, default_value = "bitcoin", name = "bitcoin|regtest|testnet")]
+        network: Network,
+        /// Existing BIP39 seed words file. Use "-" to read words from stdin.
+        #[structopt(long, name = "FILE")]
+        from_existing: Option<String>,
+        #[structopt(long, default_value = "12", name = "[12|24]")]
+        /// The number of BIP39 seed words to use
+        n_words: usize,
+    },
+    /// Initialize using a wallet descriptor
+    Descriptor {
+        /// The network name (bitcoin|regtest|testnet)
+        #[structopt(long, default_value = "bitcoin", name = "bitcoin|regtest|testnet")]
+        network: Network,
+        /// Initialize the wallet from a descriptor
+        #[structopt(name = "wpkh([AAB893A5/84'/0'/0']xpub66...mSXJj")]
+        external: String,
+        /// Optional change descriptor
+        #[structopt(name = "wpkh([AAB893A5/84'/0'/0']xpub66...mSXJj/1/*)")]
+        internal: Option<String>,
+    },
 }
 
-pub fn run_init(
-    wallet_dir: &std::path::Path,
-    InitOpt {
-        network,
-        n_words,
-        from_existing,
-    }: InitOpt,
-) -> anyhow::Result<CmdOutput> {
-    let seed_words = match from_existing {
-        Some(existing_words_file) => {
-            let words = match existing_words_file.as_str() {
-                "-" => {
-                    use io::Read;
-                    let mut words = String::new();
-                    io::stdin().read_to_string(&mut words)?;
-                    words
-                }
-                existing_words_file => {
-                    let existing_words_file = PathBuf::from_str(existing_words_file)
-                        .context("parsing existing seed words file name")?;
-                    fs::read_to_string(&existing_words_file).context(format!(
-                        "loading existing seed words from {}",
-                        existing_words_file.display()
-                    ))?
-                }
-            };
-            Mnemonic::validate(&words, Language::English).context("parsing existing seedwords")?;
-            words
-        }
-        None => {
-            let n_words = MnemonicType::for_word_count(n_words)?;
-            let seed_words: GeneratedKey<_, Segwitv0> =
-                Mnemonic::generate((n_words, Language::English))
-                    .map_err(|_| anyhow!("generating seed phrase failed"))?;
-            seed_words.phrase().into()
-        }
-    };
-
+pub fn run_init(wallet_dir: &std::path::Path, cmd: InitOpt) -> anyhow::Result<CmdOutput> {
     if wallet_dir.exists() {
         return Err(anyhow!(
             "wallet directory {} already exists -- delete it to create a new wallet",
@@ -76,23 +57,69 @@ pub fn run_init(
 
     std::fs::create_dir(&wallet_dir)?;
 
-    {
-        let mut config_file = wallet_dir.to_path_buf();
-        config_file.push("config.json");
+    match cmd {
+        InitOpt::Seed {
+            network,
+            from_existing,
+            n_words,
+        } => {
+            let wallet_key = match from_existing {
+                Some(existing_words_file) => {
+                    let seed_words = match existing_words_file.as_str() {
+                        "-" => {
+                            use io::Read;
+                            let mut words = String::new();
+                            io::stdin().read_to_string(&mut words)?;
+                            words
+                        }
+                        existing_words_file => {
+                            let existing_words_file = PathBuf::from_str(existing_words_file)
+                                .context("parsing existing seed words file name")?;
+                            fs::read_to_string(&existing_words_file).context(format!(
+                                "loading existing seed words from {}",
+                                existing_words_file.display()
+                            ))?
+                        }
+                    };
+                    Mnemonic::validate(&seed_words, Language::English)
+                        .context("parsing existing seedwords")?;
+                    let sw_file = cmd::get_seed_words_file(wallet_dir);
+                    fs::write(sw_file.clone(), seed_words.clone())?;
+                    WalletKey::SeedWordsFile
+                }
+                None => {
+                    let n_words = MnemonicType::for_word_count(n_words)?;
+                    let seed_words: GeneratedKey<_, Segwitv0> =
+                        Mnemonic::generate((n_words, Language::English))
+                            .map_err(|_| anyhow!("generating seed phrase failed"))?;
+                    let seed_words: String = seed_words.phrase().into();
+                    let sw_file = cmd::get_seed_words_file(wallet_dir);
+                    fs::write(sw_file.clone(), seed_words.clone())?;
+                    eprintln!("Wrote seeds words to {}", sw_file.display());
+                    println!("==== BIP39 seed words ====");
+                    WalletKey::SeedWordsFile
+                }
+            };
+            let mut config_file = wallet_dir.to_path_buf();
+            config_file.push("config.json");
 
-        let config = Config::default_config(network);
-        fs::write(
-            config_file,
-            serde_json::to_string_pretty(&config).unwrap().as_bytes(),
-        )?;
-    }
+            let config = Config {
+                wallet_key: Some(wallet_key),
+                ..Config::default_config(network)
+            };
+            fs::write(
+                config_file,
+                serde_json::to_string_pretty(&config).unwrap().as_bytes(),
+            )?;
+        }
+        InitOpt::Descriptor {
+            network,
+            internal,
+            external,
+        } => {
+            todo!();
+        }
+    };
 
-    let sw_file = cmd::get_seed_words_file(wallet_dir);
-
-    fs::write(sw_file.clone(), seed_words.clone())?;
-
-    eprintln!("Wrote seeds words to {}", sw_file.display());
-    println!("==== BIP39 seed words ====");
-
-    Ok(item! { "seed_words" => Cell::String(seed_words)})
+    Ok(CmdOutput::None)
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -236,7 +236,7 @@ pub fn load_wallet(
                 esplora,
             )
             .context("Initializing wallet from descriptors")?;
-            let signer = SDCardSigner::create(config.psbt_output_dir.clone());
+            let signer = SDCardSigner::create(config.psbt_output_dir.clone(), config.network);
             wallet.add_signer(
                 KeychainKind::External, //NOTE: will sign internal inputs as well!
                 SignerOrdering(100),
@@ -532,10 +532,10 @@ pub fn display_psbt(network: Network, psbt: &Psbt) -> String {
         "total".into(),
         format_amount(output_total),
     ]));
-    let (fee, feerate) = psbt.fee();
+    let (fee, feerate, fee_estimated) = psbt.fee();
 
     table.add_row(Row::new(vec![
-        "fee",
+        if fee_estimated { "est. fee" } else { "fee" },
         &format!("{:.3} sats/vb", feerate.as_sat_vb()),
         &format_amount(fee),
     ]));

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -191,7 +191,7 @@ pub fn load_wallet(
     let esplora = match AnyBlockchain::from_config(&config.blockchain)? {
         AnyBlockchain::Esplora(esplora) => esplora,
         #[allow(unreachable_patterns)]
-        _ => return Err(anyhow!("A the moment only esplora is supported")),
+        _ => return Err(anyhow!("At the moment only esplora is supported")),
     };
 
     let (wallet, keychain) = match config.wallet_key {
@@ -209,7 +209,6 @@ pub fn load_wallet(
             let seed = Seed::new(&mnemonic, "");
             seed_bytes.copy_from_slice(seed.as_bytes());
             let xpriv = ExtendedPrivKey::new_master(config.network, &seed_bytes).unwrap();
-            // ExtendedPrivKey using BIP 84 into descriptors
             let keychain = Keychain::new(seed_bytes);
 
             (
@@ -239,7 +238,7 @@ pub fn load_wallet(
             .context("Initializing wallet from descriptors")?;
             let signer = SDCardSigner::create(config.psbt_output_dir.clone());
             wallet.add_signer(
-                KeychainKind::External,
+                KeychainKind::External, //NOTE: will sign internal inputs as well!
                 SignerOrdering(100),
                 Arc::new(signer),
             );

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -7,9 +7,7 @@ use bdk::{
     bitcoin::{
         consensus::encode,
         util::{
-            address::Payload,
-            bip32::{self, ExtendedPrivKey, ExtendedPubKey},
-            psbt::PartiallySignedTransaction as Psbt,
+            address::Payload, bip32::ExtendedPrivKey, psbt::PartiallySignedTransaction as Psbt,
         },
         Address, Amount, Network, Txid,
     },
@@ -153,11 +151,6 @@ pub fn load_party(
     let (wallet, bet_db, keychain, config) = load_wallet(wallet_dir).context("loading wallet")?;
     let party = Party::new(wallet, bet_db, keychain, config.blockchain);
     Ok(party)
-}
-
-pub enum ExtendedKey {
-    Public(ExtendedPubKey, bip32::Fingerprint),
-    Private(ExtendedPrivKey),
 }
 
 pub fn load_wallet(
@@ -532,11 +525,12 @@ pub fn display_psbt(network: Network, psbt: &Psbt) -> String {
         "total".into(),
         format_amount(output_total),
     ]));
-    let (fee, feerate, fee_estimated) = psbt.fee();
+    let (fee, feerate, feerate_estimated) = psbt.fee();
 
+    let est = if feerate_estimated { "(est.)" } else { "" };
     table.add_row(Row::new(vec![
-        if fee_estimated { "est. fee" } else { "fee" },
-        &format!("{:.3} sats/vb", feerate.as_sat_vb()),
+        "fee",
+        &format!("{:.3} sats/vb {}", feerate.as_sat_vb(), est),
         &format_amount(fee),
     ]));
 

--- a/src/cmd/wallet.rs
+++ b/src/cmd/wallet.rs
@@ -271,9 +271,12 @@ impl SpendOpt {
         };
 
         party.wallet().sign(&mut psbt, SignOptions::default())?;
+
         let finalized = party
             .wallet()
             .finalize_psbt(&mut psbt, SignOptions::default())?;
+
+        assert!(finalized, "transaction must be finalized at this point");
 
         let (output, txid) = cmd::decide_to_broadcast(
             party.wallet().network(),
@@ -295,7 +298,6 @@ impl SpendOpt {
                 }
             }
         }
-        assert!(finalized, "transaction must be finalized at this point");
 
         Ok(output)
     }

--- a/src/cmd/wallet.rs
+++ b/src/cmd/wallet.rs
@@ -1,13 +1,12 @@
 use super::*;
-use crate::{amount_ext::FromCliStr, betting::BetState, cmd, config::WalletKey, item};
+use crate::{amount_ext::FromCliStr, betting::BetState, cmd, item};
 use bdk::{
-    bitcoin::{util::psbt::PartiallySignedTransaction, Address, OutPoint, Script, Txid},
+    bitcoin::{Address, OutPoint, Script, Txid},
     blockchain::EsploraBlockchain,
     database::Database,
     wallet::{coin_selection::CoinSelectionAlgorithm, tx_builder::TxBuilderContext, AddressIndex},
     KeychainKind, LocalUtxo, SignOptions, TxBuilder,
 };
-use core::str::FromStr;
 use std::collections::HashMap;
 use structopt::StructOpt;
 
@@ -232,7 +231,6 @@ pub struct SpendOpt {
 impl SpendOpt {
     pub fn spend_coins<D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>, Ctx: TxBuilderContext>(
         self,
-        wallet_dir: &std::path::Path,
         party: &Party<EsploraBlockchain, D>,
         mut builder: TxBuilder<'_, EsploraBlockchain, D, Cs, Ctx>,
     ) -> anyhow::Result<CmdOutput> {
@@ -272,73 +270,33 @@ impl SpendOpt {
             (psbt, vec![])
         };
 
-        let config = load_config(wallet_dir).context("loading config")?;
+        party.wallet().sign(&mut psbt, SignOptions::default())?;
+        let finalized = party
+            .wallet()
+            .finalize_psbt(&mut psbt, SignOptions::default())?;
 
-        let output = match config.wallet_key {
-            WalletKey::SeedWordsFile {} => {
-                party.wallet().sign(&mut psbt, SignOptions::default())?;
-                let finalized = party
-                    .wallet()
-                    .finalize_psbt(&mut psbt, SignOptions::default())?;
+        let (output, txid) = cmd::decide_to_broadcast(
+            party.wallet().network(),
+            party.wallet().client(),
+            psbt,
+            yes,
+            print_tx,
+        )?;
 
-                let (output, txid) = cmd::decide_to_broadcast(
-                    party.wallet().network(),
-                    party.wallet().client(),
-                    psbt,
-                    yes,
-                    print_tx,
-                )?;
-
-                if let Some(txid) = txid {
-                    if !print_tx {
-                        for bet_id in claiming_bet_ids {
-                            if let Err(e) = party.take_next_action(bet_id, false) {
-                                eprintln!(
-                                    "error updating state of bet {} after broadcasting claim tx {}: {}",
-                                    bet_id, txid, e
-                                );
-                            }
-                        }
+        if let Some(txid) = txid {
+            if !print_tx {
+                for bet_id in claiming_bet_ids {
+                    if let Err(e) = party.take_next_action(bet_id, false) {
+                        eprintln!(
+                            "error updating state of bet {} after broadcasting claim tx {}: {}",
+                            bet_id, txid, e
+                        );
                     }
                 }
-                assert!(finalized, "transaction must be finalized at this point");
-                output
             }
-            WalletKey::Descriptor {
-                external: _,
-                internal: _,
-            } => {
-                let txid = psbt.clone().extract_tx().txid();
+        }
+        assert!(finalized, "transaction must be finalized at this point");
 
-                let mut psbt_file = PathBuf::from(config.psbt_output_dir.clone());
-                psbt_file.push(format!("{}.psbt", txid.to_string()));
-
-                fs::write(psbt_file.clone(), psbt.to_string())
-                    .context("writing PSBT file to SD path")?;
-                eprintln!("Wrote PSBT to {}", psbt_file.display());
-
-                let mut signed_psbt_file = PathBuf::from(config.psbt_output_dir.clone());
-                signed_psbt_file.push(format!("{}-signed.psbt", txid.to_string()));
-                eprintln!(
-                    "Please sign the PSBT and save it to {}. Press enter once signed.",
-                    signed_psbt_file.display()
-                );
-                let mut input = String::new();
-                let _ = std::io::stdin().read_line(&mut input);
-                let contents = fs::read_to_string(signed_psbt_file.clone())
-                    .with_context(|| format!("Reading PSBT file {}", signed_psbt_file.display()))?;
-                let psbt = PartiallySignedTransaction::from_str(&contents.trim())?;
-
-                let (output, _txid) = cmd::decide_to_broadcast(
-                    party.wallet().network(),
-                    party.wallet().client(),
-                    psbt,
-                    yes,
-                    print_tx,
-                )?;
-                output
-            }
-        };
         Ok(output)
     }
 }
@@ -356,7 +314,7 @@ pub fn run_send(wallet_dir: &std::path::Path, send_opt: SendOpt) -> anyhow::Resu
         ValueChoice::Amount(amount) => builder.add_recipient(to.script_pubkey(), amount.as_sat()),
     };
 
-    spend_opt.spend_coins(&wallet_dir, &party, builder)
+    spend_opt.spend_coins(&party, builder)
 }
 
 #[derive(StructOpt, Debug, Clone)]
@@ -594,5 +552,5 @@ pub fn run_split_cmd(wallet_dir: &std::path::Path, opt: SplitOpt) -> anyhow::Res
         }
     };
 
-    spend_opt.spend_coins(&wallet_dir, &party, builder)
+    spend_opt.spend_coins(&party, builder)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,10 +3,20 @@ use bdk::{
     blockchain::{esplora::EsploraBlockchainConfig, AnyBlockchainConfig},
 };
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum WalletKeys {
+pub enum WalletKeysOld {
     SeedWordsFile,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case", tag = "kind")]
+pub enum WalletKey {
+    SeedWordsFile,
+    Descriptor {
+        external: String,
+        internal: Option<String>,
+    },
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -22,7 +32,9 @@ pub struct Config {
     pub network: Network,
     pub blockchain: AnyBlockchainConfig,
     pub kind: WalletKind,
-    pub keys: WalletKeys,
+    #[serde(alias = "keys", skip_serializing_if = "Option::is_none")]
+    pub wallet_key_old: Option<WalletKeysOld>,
+    pub wallet_key: Option<WalletKey>,
 }
 
 impl Config {
@@ -45,7 +57,8 @@ impl Config {
             network,
             blockchain,
             kind: WalletKind::P2wpkh,
-            keys: WalletKeys::SeedWordsFile,
+            wallet_key_old: None,
+            wallet_key: Some(WalletKey::SeedWordsFile),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,39 +2,76 @@ use bdk::{
     bitcoin::Network,
     blockchain::{esplora::EsploraBlockchainConfig, AnyBlockchainConfig},
 };
+use std::path::PathBuf;
 
-#[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum WalletKeysOld {
+pub enum WalletKeys {
     SeedWordsFile,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "kebab-case", tag = "kind")]
-pub enum WalletKey {
-    SeedWordsFile,
-    Descriptor {
-        external: String,
-        internal: Option<String>,
-    },
-}
-
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum WalletKind {
+pub enum WalletKeyOld {
     #[serde(rename = "p2wpkh")]
     P2wpkh,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub struct Config {
+pub enum WalletKey {
+    Descriptor {
+        external: String,
+        internal: Option<String>,
+    },
+    SeedWordsFile {},
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ConfigV0 {
     pub network: Network,
     pub blockchain: AnyBlockchainConfig,
-    pub kind: WalletKind,
-    #[serde(alias = "keys", skip_serializing_if = "Option::is_none")]
-    pub wallet_key_old: Option<WalletKeysOld>,
-    pub wallet_key: Option<WalletKey>,
+    pub keys: WalletKeys,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case", tag = "version")]
+pub enum VersionedConfig {
+    #[serde(rename = "1")]
+    V1(Config),
+}
+
+impl From<ConfigV0> for Config {
+    fn from(from: ConfigV0) -> Self {
+        let mut psbt_output_dir = PathBuf::new();
+        psbt_output_dir.push(&dirs::home_dir().unwrap());
+        psbt_output_dir.push("psbts");
+
+        Config {
+            network: from.network,
+            psbt_output_dir,
+            blockchain: from.blockchain,
+            wallet_key: WalletKey::SeedWordsFile {},
+        }
+    }
+}
+
+impl From<VersionedConfig> for Config {
+    fn from(from: VersionedConfig) -> Self {
+        match from {
+            VersionedConfig::V1(config) => config,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Config {
+    pub network: Network,
+    pub psbt_output_dir: PathBuf,
+    pub blockchain: AnyBlockchainConfig,
+    pub wallet_key: WalletKey,
 }
 
 impl Config {
@@ -53,12 +90,18 @@ impl Config {
             ..EsploraBlockchainConfig::new(url.into())
         });
 
+        let mut psbt_output_dir = PathBuf::new();
+        psbt_output_dir.push(&dirs::home_dir().unwrap());
+        psbt_output_dir.push("psbts");
+
         Config {
             network,
+            psbt_output_dir,
             blockchain,
-            kind: WalletKind::P2wpkh,
-            wallet_key_old: None,
-            wallet_key: Some(WalletKey::SeedWordsFile),
+            wallet_key: WalletKey::SeedWordsFile {},
         }
+    }
+    pub fn into_versioned(self) -> VersionedConfig {
+        VersionedConfig::V1(self)
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,7 @@ pub enum WalletKeyOld {
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", tag = "kind")]
 pub enum WalletKey {
     Descriptor {
         external: String,

--- a/src/fee_spec.rs
+++ b/src/fee_spec.rs
@@ -74,7 +74,7 @@ impl FromStr for FeeSpec {
             return Ok(FeeSpec::Height(in_blocks));
         }
 
-        Err(anyhow!("{} is not a valid fee specification"))
+        Err(anyhow!("'{}' is not a valid fee specification", string))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod encode;
 mod fee_spec;
 pub mod keychain;
 pub mod psbt_ext;
+pub mod sd_card_signer;
 pub use fee_spec::*;
 
 pub use chacha20::cipher;

--- a/src/psbt_ext.rs
+++ b/src/psbt_ext.rs
@@ -16,12 +16,12 @@ impl PsbtFeeRate for Psbt {
             .map(|x| x.witness_utxo.as_ref().map(|x| x.value).unwrap_or(0))
             .sum();
 
-        let mut fee_estimated = false;
+        let mut feerate_estimated = false;
         for input in &mut psbt.inputs {
             if input.final_script_witness.is_none() {
                 // FIXME: (Does not work for other script types, taproot)
                 input.final_script_witness = Some(vec![vec![0u8; 73], vec![0u8; 33]]);
-                fee_estimated = true;
+                feerate_estimated = true;
             };
         }
 
@@ -30,6 +30,6 @@ impl PsbtFeeRate for Psbt {
         let feerate = FeeRate::from_sat_per_vb(
             fee as f32 / (self.clone().extract_tx().get_weight() as f32 / 4.0),
         );
-        (Amount::from_sat(fee), feerate, fee_estimated)
+        (Amount::from_sat(fee), feerate, feerate_estimated)
     }
 }

--- a/src/psbt_ext.rs
+++ b/src/psbt_ext.rs
@@ -4,21 +4,32 @@ use bdk::{
 };
 
 pub trait PsbtFeeRate {
-    fn fee(&self) -> (Amount, FeeRate);
+    fn fee(&self) -> (Amount, FeeRate, bool);
 }
 
 impl PsbtFeeRate for Psbt {
-    fn fee(&self) -> (Amount, FeeRate) {
+    fn fee(&self) -> (Amount, FeeRate, bool) {
+        let mut psbt = self.clone();
         let input_value: u64 = self
             .inputs
             .iter()
             .map(|x| x.witness_utxo.as_ref().map(|x| x.value).unwrap_or(0))
             .sum();
+
+        let mut fee_estimated = false;
+        for input in &mut psbt.inputs {
+            if input.final_script_witness.is_none() {
+                // FIXME: (Does not work for other script types, taproot)
+                input.final_script_witness = Some(vec![vec![0u8; 73], vec![0u8; 33]]);
+                fee_estimated = true;
+            };
+        }
+
         let output_value: u64 = self.global.unsigned_tx.output.iter().map(|x| x.value).sum();
         let fee = input_value - output_value;
         let feerate = FeeRate::from_sat_per_vb(
             fee as f32 / (self.clone().extract_tx().get_weight() as f32 / 4.0),
         );
-        (Amount::from_sat(fee), feerate)
+        (Amount::from_sat(fee), feerate, fee_estimated)
     }
 }

--- a/src/sd_card_signer.rs
+++ b/src/sd_card_signer.rs
@@ -1,0 +1,79 @@
+use anyhow::Context;
+use bdk::{
+    bitcoin::{
+        secp256k1::{All, Secp256k1},
+        util::psbt::PartiallySignedTransaction,
+    },
+    wallet::signer::{Signer, SignerError, SignerId},
+};
+use core::str::FromStr;
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub struct SDCardSigner {
+    psbt_output_dir: PathBuf,
+}
+
+impl SDCardSigner {
+    pub fn create(psbt_output_dir: PathBuf) -> Self {
+        SDCardSigner { psbt_output_dir }
+    }
+}
+
+impl Signer for SDCardSigner {
+    fn sign(
+        &self,
+        psbt: &mut PartiallySignedTransaction,
+        _input_index: Option<usize>,
+        _secp: &Secp256k1<All>,
+    ) -> Result<(), SignerError> {
+        // Probably should figure out how to incorporate SignerErrors here
+        let txid = psbt.clone().extract_tx().txid();
+        let mut psbt_file = PathBuf::from(self.psbt_output_dir.clone());
+        psbt_file.push(format!("{}.psbt", txid.to_string()));
+
+        let _ = std::fs::write(psbt_file.clone(), psbt.to_string())
+            .context("writing PSBT file to SD path");
+
+        if !psbt_file.clone().exists() {
+            eprintln!("Failed to write PSBT to {}", psbt_file.display());
+            return Err(SignerError::UserCanceled);
+        }
+
+        eprintln!("Wrote PSBT to {}", psbt_file.display());
+
+        let mut signed_psbt_file = PathBuf::from(self.psbt_output_dir.clone());
+        signed_psbt_file.push(format!("{}-signed.psbt", txid.to_string()));
+        eprintln!(
+            "Please sign the PSBT and save it to {}",
+            signed_psbt_file.display()
+        );
+        eprintln!("Press enter once signed.");
+        let mut input = String::new();
+        let _ = std::io::stdin().read_line(&mut input);
+
+        let contents = std::fs::read_to_string(signed_psbt_file.clone())
+            .with_context(|| format!("Reading PSBT file {}", signed_psbt_file.display()));
+        let psbt_result = PartiallySignedTransaction::from_str(&contents.unwrap().trim());
+
+        if let Err(e) = psbt_result {
+            eprintln!(
+                "Failed to read signed PSBT file {}",
+                signed_psbt_file.display()
+            );
+            eprintln!("{}", e);
+            return Err(SignerError::UserCanceled);
+        };
+        *psbt = psbt_result.unwrap();
+        Ok(())
+    }
+
+    fn id(&self, _secp: &Secp256k1<All>) -> SignerId {
+        // Fingerprint/PubKey is not used in anything important that we need just yet
+        SignerId::Dummy(3735928559)
+    }
+
+    fn sign_whole_tx(&self) -> bool {
+        true
+    }
+}

--- a/src/sd_card_signer.rs
+++ b/src/sd_card_signer.rs
@@ -69,22 +69,18 @@ impl Signer for SDCardSigner {
             "Please sign the PSBT and save it to {}",
             signed_psbt_file.display()
         );
+
         eprintln!("Press enter once signed.");
-        let mut input = String::new();
-        let _ = std::io::stdin().read_line(&mut input);
-
-        let contents = match std::fs::read_to_string(signed_psbt_file.clone()) {
-            Ok(contents) => contents,
-            Err(e) => {
-                eprintln!(
-                    "Failed to read PSBT file {}: {}",
-                    signed_psbt_file.display(),
-                    e
-                );
-                return Err(SignerError::UserCanceled);
-            }
+        let contents = loop {
+            let mut input = String::new();
+            let _ = std::io::stdin().read_line(&mut input);
+            match std::fs::read_to_string(signed_psbt_file.clone()) {
+                Ok(contents) => break contents,
+                Err(e) => {
+                    eprintln!("Error reading file: {}\nPress enter to try again.", e);
+                }
+            };
         };
-
         let psbt_result = PartiallySignedTransaction::from_str(&contents.trim());
 
         if let Err(e) = psbt_result {


### PR DESCRIPTION
* Fix anyhow related compilation errors, print values
* InitOpts for Seed and Descriptor subcommands
* Versioned config, init xpub, secret protocol randomness
* Add psbt-output-dir init option, and wait for signing

New `init` subcommands
`gun init seed`
`gun init descriptor`
`gun init xpub`
`descriptor` and `xpub` have an `--psbt-output-dir` that defaults to `$GUNDIR/psbts/
`


config.json layout is not identical to https://github.com/LLFourn/gun/issues/62
Looks like
```
  "wallet-key": {
    "descriptor": {
      "external": "wpkh([81148886/84'/0'/0'].../0/*)",
      "internal": "wpkh([81148886/84'/0'/0'].../1/*)"
    }
```

Seed phrase no longer printed after `gun init seed`.

Since PSBT betting is not yet supported, `gun bet` gives `Error: Betting is not yet supported for descriptor based wallets.` when using a descriptor wallet.


Currently `WalletKey::SeedWordsFile` still gets secret randomness from the seed phrase, whereas `WalletKey::Descriptor` uses the `secret_protocol_randomness` for the keychain. Would also using `secret_protocol_randomness` for seed wallets break any ongoing bets?