### PR TITLE
Use LargestFirst coin selection in bets

### DIFF
--- a/src/betting/party/offer.rs
+++ b/src/betting/party/offer.rs
@@ -5,7 +5,7 @@ use bdk::{
     bitcoin::Amount,
     database::BatchDatabase,
     miniscript::DescriptorTrait,
-    wallet::{tx_builder::TxOrdering, IsDust},
+    wallet::{coin_selection::LargestFirstCoinSelection, tx_builder::TxOrdering, IsDust},
     SignOptions,
 };
 use chacha20::cipher::StreamCipher;
@@ -51,7 +51,10 @@ impl<D: BatchDatabase> Party<bdk::blockchain::EsploraBlockchain, D> {
             randomize,
         );
 
-        let mut builder = self.wallet.build_tx();
+        let mut builder = self
+            .wallet
+            .build_tx()
+            .coin_selection(LargestFirstCoinSelection);
         builder
             .ordering(TxOrdering::Bip69Lexicographic)
             .enable_rbf();

--- a/src/betting/party/proposal.rs
+++ b/src/betting/party/proposal.rs
@@ -3,6 +3,7 @@ use anyhow::{anyhow, Context};
 use bdk::{
     bitcoin::{Amount, Script},
     database::BatchDatabase,
+    wallet::coin_selection::LargestFirstCoinSelection,
     FeeRate,
 };
 use olivia_core::{OracleEvent, OracleId};
@@ -25,7 +26,10 @@ impl<D: BatchDatabase> Party<bdk::blockchain::EsploraBlockchain, D> {
             ));
         }
 
-        let mut builder = self.wallet.build_tx();
+        let mut builder = self
+            .wallet
+            .build_tx()
+            .coin_selection(LargestFirstCoinSelection);
         // we use a 0 feerate because the offerer will pay the fee
         builder.fee_rate(FeeRate::from_sat_per_vb(0.0));
 


### PR DESCRIPTION
So we minimize the number of inputs and therefore the tx size.

fixes #56 