### PR TITLE
BIP39 Passphrase with new XKeySigner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,6 +616,7 @@ dependencies = [
  "olivia_describe",
  "olivia_secp256k1",
  "rand 0.8.4",
+ "rpassword",
  "serde",
  "serde_json",
  "sha2",
@@ -1116,6 +1117,16 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rpassword"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc936cf8a7ea60c58f030fd36a612a48f440610214dc54bc36431f9ea0c3efb"
+dependencies = [
+ "libc",
  "winapi 0.3.9",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ bincode = "1.3"
 anyhow = "1"
 thiserror = "1.0"
 rand = { version = "0.8", features = ["getrandom"] }
-rpassword = "5.0.1"
+rpassword = "5"
 structopt = "0.3"
 miniscript = { version = "6", features = ["serde"] }
 term-table = {  version = "1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ bincode = "1.3"
 anyhow = "1"
 thiserror = "1.0"
 rand = { version = "0.8", features = ["getrandom"] }
+rpassword = "5.0.1"
 structopt = "0.3"
 miniscript = { version = "6", features = ["serde"] }
 term-table = {  version = "1", default-features = false }

--- a/src/bip85.rs
+++ b/src/bip85.rs
@@ -1,0 +1,63 @@
+use bdk::bitcoin::{
+    hashes::{sha512, Hash, HashEngine, Hmac, HmacEngine},
+    secp256k1::Secp256k1,
+    util::bip32::{DerivationPath, ExtendedPrivKey},
+};
+
+pub fn get_bip85_bytes<const L: usize>(xpriv: ExtendedPrivKey, path: DerivationPath) -> [u8; L] {
+    let secp = Secp256k1::signing_only();
+    let bip85_key = xpriv.derive_priv(&secp, &path).unwrap();
+
+    let mut engine = HmacEngine::<sha512::Hash>::new("bip-entropy-from-k".as_bytes());
+    engine.input(&bip85_key.private_key.serialize_secret());
+    let hash = Hmac::<sha512::Hash>::from_engine(engine).into_inner();
+    hash[(64 - L)..].try_into().unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use olivia_secp256k1::fun::hex;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_vector_1() {
+        let xpriv = ExtendedPrivKey::from_str("xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBqsx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhUtyoFnCNkfmXRyPXLjbKb").expect("reading extended private key");
+        let path = DerivationPath::from_str("m/83696968'/0'/0'").expect("reading derivation path");
+        let expected_hex =
+            hex::decode("efecfbccffea313214232d29e71563d941229afb4338c21f9517c41aaa0d16f00b83d2a09ef747e7a64e8e2bd5a14869e693da66ce94ac2da570ab7ee48618f7")
+                .expect("reading in expected test bytes");
+        assert_eq!(get_bip85_bytes::<64>(xpriv, path).to_vec(), expected_hex);
+    }
+
+    #[test]
+    fn test_vector_2() {
+        let xpriv = ExtendedPrivKey::from_str("xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBqsx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhUtyoFnCNkfmXRyPXLjbKb").expect("reading extended private key");
+        let path = DerivationPath::from_str("m/83696968'/0'/1'").expect("reading derivation path");
+        let expected_hex =
+            hex::decode("70c6e3e8ebee8dc4c0dbba66076819bb8c09672527c4277ca8729532ad711872218f826919f6b67218adde99018a6df9095ab2b58d803b5b93ec9802085a690e")
+                .expect("reading in expected test bytes");
+        assert_eq!(get_bip85_bytes::<64>(xpriv, path).to_vec(), expected_hex);
+    }
+
+    #[test]
+    fn test_vector_32() {
+        let xpriv = ExtendedPrivKey::from_str("xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBqsx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhUtyoFnCNkfmXRyPXLjbKb").expect("reading extended private key");
+        let path = DerivationPath::from_str("m/83696968'/32'/0'").expect("reading derivation path");
+        let expected_hex =
+            hex::decode("ead0b33988a616cf6a497f1c169d9e92562604e38305ccd3fc96f2252c177682")
+                .expect("reading in expected test bytes");
+        assert_eq!(get_bip85_bytes::<32>(xpriv, path).to_vec(), expected_hex);
+    }
+
+    #[test]
+    fn test_vector_128169() {
+        let xpriv = ExtendedPrivKey::from_str("xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBqsx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhUtyoFnCNkfmXRyPXLjbKb").expect("reading extended private key");
+        let path = DerivationPath::from_str("m/83696968'/128169'/64'/0'")
+            .expect("reading derivation path");
+        let expected_hex =
+            hex::decode("492db4698cf3b73a5a24998aa3e9d7fa96275d85724a91e71aa2d645442f878555d078fd1f1f67e368976f04137b1f7a0d19232136ca50c44614af72b5582a5c")
+                .expect("reading in expected test bytes");
+        assert_eq!(get_bip85_bytes::<64>(xpriv, path).to_vec(), expected_hex);
+    }
+}

--- a/src/bip85.rs
+++ b/src/bip85.rs
@@ -1,26 +1,26 @@
 use bdk::bitcoin::{
     hashes::{sha512, Hash, HashEngine, Hmac, HmacEngine},
-    secp256k1::Secp256k1,
+    secp256k1::{Secp256k1, SignOnly},
     util::bip32::{ChildNumber, DerivationPath, ExtendedPrivKey},
 };
 
 pub fn get_bip85_bytes<const L: usize>(
     xpriv: ExtendedPrivKey,
-    app_num: u32,
     index: u32,
+    secp: &Secp256k1<SignOnly>,
 ) -> [u8; L] {
     let path = DerivationPath::from(vec![
         ChildNumber::Hardened { index: 83696968 },
-        ChildNumber::Hardened { index: app_num },
+        ChildNumber::Hardened { index: 128169 },
+        ChildNumber::Hardened { index: L as u32 },
         ChildNumber::Hardened { index: index },
     ]);
-    let secp = Secp256k1::signing_only();
     let bip85_key = xpriv.derive_priv(&secp, &path).unwrap();
 
     let mut engine = HmacEngine::<sha512::Hash>::new("bip-entropy-from-k".as_bytes());
     engine.input(&bip85_key.private_key.serialize_secret());
     let hash = Hmac::<sha512::Hash>::from_engine(engine).into_inner();
-    hash[(64 - L)..].try_into().unwrap()
+    hash[..L].try_into().unwrap()
 }
 
 #[cfg(test)]
@@ -30,20 +30,28 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
-    fn test_vector_1() {
+    fn test_vector_32() {
+        let secp = Secp256k1::signing_only();
         let xpriv = ExtendedPrivKey::from_str("xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBqsx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhUtyoFnCNkfmXRyPXLjbKb").expect("reading extended private key");
         let expected_hex =
-            hex::decode("efecfbccffea313214232d29e71563d941229afb4338c21f9517c41aaa0d16f00b83d2a09ef747e7a64e8e2bd5a14869e693da66ce94ac2da570ab7ee48618f7")
+            hex::decode("ea3ceb0b02ee8e587779c63f4b7b3a21e950a213f1ec53cab608d13e8796e6dc")
                 .expect("reading in expected test bytes");
-        assert_eq!(get_bip85_bytes::<64>(xpriv, 0, 0).to_vec(), expected_hex);
+        assert_eq!(
+            get_bip85_bytes::<32>(xpriv, 0, &secp).to_vec(),
+            expected_hex
+        );
     }
 
     #[test]
-    fn test_vector_2() {
+    fn test_vector_64() {
+        let secp = Secp256k1::signing_only();
         let xpriv = ExtendedPrivKey::from_str("xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBqsx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhUtyoFnCNkfmXRyPXLjbKb").expect("reading extended private key");
         let expected_hex =
-            hex::decode("70c6e3e8ebee8dc4c0dbba66076819bb8c09672527c4277ca8729532ad711872218f826919f6b67218adde99018a6df9095ab2b58d803b5b93ec9802085a690e")
+            hex::decode("492db4698cf3b73a5a24998aa3e9d7fa96275d85724a91e71aa2d645442f878555d078fd1f1f67e368976f04137b1f7a0d19232136ca50c44614af72b5582a5c")
                 .expect("reading in expected test bytes");
-        assert_eq!(get_bip85_bytes::<64>(xpriv, 0, 1).to_vec(), expected_hex);
+        assert_eq!(
+            get_bip85_bytes::<64>(xpriv, 0, &secp).to_vec(),
+            expected_hex
+        );
     }
 }

--- a/src/bip85.rs
+++ b/src/bip85.rs
@@ -1,10 +1,19 @@
 use bdk::bitcoin::{
     hashes::{sha512, Hash, HashEngine, Hmac, HmacEngine},
     secp256k1::Secp256k1,
-    util::bip32::{DerivationPath, ExtendedPrivKey},
+    util::bip32::{ChildNumber, DerivationPath, ExtendedPrivKey},
 };
 
-pub fn get_bip85_bytes<const L: usize>(xpriv: ExtendedPrivKey, path: DerivationPath) -> [u8; L] {
+pub fn get_bip85_bytes<const L: usize>(
+    xpriv: ExtendedPrivKey,
+    app_num: u32,
+    index: u32,
+) -> [u8; L] {
+    let path = DerivationPath::from(vec![
+        ChildNumber::Hardened { index: 83696968 },
+        ChildNumber::Hardened { index: app_num },
+        ChildNumber::Hardened { index: index },
+    ]);
     let secp = Secp256k1::signing_only();
     let bip85_key = xpriv.derive_priv(&secp, &path).unwrap();
 
@@ -23,41 +32,18 @@ mod tests {
     #[test]
     fn test_vector_1() {
         let xpriv = ExtendedPrivKey::from_str("xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBqsx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhUtyoFnCNkfmXRyPXLjbKb").expect("reading extended private key");
-        let path = DerivationPath::from_str("m/83696968'/0'/0'").expect("reading derivation path");
         let expected_hex =
             hex::decode("efecfbccffea313214232d29e71563d941229afb4338c21f9517c41aaa0d16f00b83d2a09ef747e7a64e8e2bd5a14869e693da66ce94ac2da570ab7ee48618f7")
                 .expect("reading in expected test bytes");
-        assert_eq!(get_bip85_bytes::<64>(xpriv, path).to_vec(), expected_hex);
+        assert_eq!(get_bip85_bytes::<64>(xpriv, 0, 0).to_vec(), expected_hex);
     }
 
     #[test]
     fn test_vector_2() {
         let xpriv = ExtendedPrivKey::from_str("xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBqsx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhUtyoFnCNkfmXRyPXLjbKb").expect("reading extended private key");
-        let path = DerivationPath::from_str("m/83696968'/0'/1'").expect("reading derivation path");
         let expected_hex =
             hex::decode("70c6e3e8ebee8dc4c0dbba66076819bb8c09672527c4277ca8729532ad711872218f826919f6b67218adde99018a6df9095ab2b58d803b5b93ec9802085a690e")
                 .expect("reading in expected test bytes");
-        assert_eq!(get_bip85_bytes::<64>(xpriv, path).to_vec(), expected_hex);
-    }
-
-    #[test]
-    fn test_vector_32() {
-        let xpriv = ExtendedPrivKey::from_str("xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBqsx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhUtyoFnCNkfmXRyPXLjbKb").expect("reading extended private key");
-        let path = DerivationPath::from_str("m/83696968'/32'/0'").expect("reading derivation path");
-        let expected_hex =
-            hex::decode("ead0b33988a616cf6a497f1c169d9e92562604e38305ccd3fc96f2252c177682")
-                .expect("reading in expected test bytes");
-        assert_eq!(get_bip85_bytes::<32>(xpriv, path).to_vec(), expected_hex);
-    }
-
-    #[test]
-    fn test_vector_128169() {
-        let xpriv = ExtendedPrivKey::from_str("xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBqsx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhUtyoFnCNkfmXRyPXLjbKb").expect("reading extended private key");
-        let path = DerivationPath::from_str("m/83696968'/128169'/64'/0'")
-            .expect("reading derivation path");
-        let expected_hex =
-            hex::decode("492db4698cf3b73a5a24998aa3e9d7fa96275d85724a91e71aa2d645442f878555d078fd1f1f67e368976f04137b1f7a0d19232136ca50c44614af72b5582a5c")
-                .expect("reading in expected test bytes");
-        assert_eq!(get_bip85_bytes::<64>(xpriv, path).to_vec(), expected_hex);
+        assert_eq!(get_bip85_bytes::<64>(xpriv, 0, 1).to_vec(), expected_hex);
     }
 }

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -5,11 +5,7 @@ use crate::{
 };
 use anyhow::{anyhow, Context};
 use bdk::{
-    bitcoin::{
-        secp256k1::Secp256k1,
-        util::bip32::{DerivationPath, ExtendedPrivKey},
-        Network,
-    },
+    bitcoin::{secp256k1::Secp256k1, util::bip32::ExtendedPrivKey, Network},
     database::MemoryDatabase,
     keys::{
         bip39::{Language, Mnemonic, WordCount},
@@ -222,10 +218,7 @@ pub fn run_init(wallet_dir: &std::path::Path, cmd: InitOpt) -> anyhow::Result<Cm
             let seed_bytes = mnemonic.to_seed(passphrase);
             let xpriv = ExtendedPrivKey::new_master(common_args.network, &seed_bytes).unwrap();
 
-            let bip85_bytes: [u8; 64] = get_bip85_bytes::<64>(
-                xpriv,
-                DerivationPath::from_str("m/83696968'/128169'/64'/330'").unwrap(),
-            );
+            let bip85_bytes: [u8; 64] = get_bip85_bytes::<64>(xpriv, 330, 0);
             let secret_file = wallet_dir.join("secret_protocol_randomness");
             fs::write(secret_file, hex::encode(&bip85_bytes))?;
 

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cmd::{self, read_yn},
+    cmd::{self},
     config::{Config, GunSigner},
 };
 use anyhow::{anyhow, Context};
@@ -197,23 +197,17 @@ pub fn run_init(wallet_dir: &std::path::Path, cmd: InitOpt) -> anyhow::Result<Cm
             })?;
 
             let passphrase = if has_passphrase {
+                eprintln!("Warning: by using a passphrase you are mutating the secret derived from your seed words. \
+                If you lose or forget your seedphrase, you will lose access to your funds.");
                 loop {
-                    let mut passphrase = String::new();
-                    eprintln!("Please enter your wallet passphrase: ");
-                    let _ = std::io::stdin().read_line(&mut passphrase);
-                    passphrase = passphrase.trim().to_string();
-
-                    let mut passphrase_confirmation = String::new();
-                    eprintln!("Please confirm your wallet passphrase: ");
-                    let _ = std::io::stdin().read_line(&mut passphrase_confirmation);
-                    passphrase_confirmation = passphrase_confirmation.trim().to_string();
-
+                    let passphrase =
+                        rpassword::prompt_password_stderr("Please enter your wallet passphrase: ")?;
+                    let passphrase_confirmation = rpassword::prompt_password_stderr(
+                        "Please confirm your wallet passphrase: ",
+                    )?;
                     if !passphrase.eq(&passphrase_confirmation) {
                         eprintln!("Mismatching passphrases. Try again.\n")
-                    } else if read_yn(&format!(
-                        "Your wallet passphrase will be set as `{}`\nOk",
-                        passphrase
-                    )) {
+                    } else {
                         break passphrase;
                     }
                 }

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -235,8 +235,11 @@ pub fn run_init(wallet_dir: &std::path::Path, cmd: InitOpt) -> anyhow::Result<Cm
 
             let signers = vec![GunSigner::SeedWordsFile {
                 file_path: sw_file,
-                has_passphrase,
-                master_fingerprint,
+                passphrase_fingerprint: if has_passphrase {
+                    Some(master_fingerprint)
+                } else {
+                    None
+                },
             }];
 
             let external = temp_wallet

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -218,11 +218,11 @@ pub fn run_init(wallet_dir: &std::path::Path, cmd: InitOpt) -> anyhow::Result<Cm
             let seed_bytes = mnemonic.to_seed(passphrase);
             let xpriv = ExtendedPrivKey::new_master(common_args.network, &seed_bytes).unwrap();
 
-            let bip85_bytes: [u8; 64] = get_bip85_bytes::<64>(xpriv, 330, 0);
+            let secp = Secp256k1::signing_only();
+            let bip85_bytes: [u8; 64] = get_bip85_bytes::<64>(xpriv, 330, &secp);
             let secret_file = wallet_dir.join("secret_protocol_randomness");
             fs::write(secret_file, hex::encode(&bip85_bytes))?;
 
-            let secp = Secp256k1::signing_only();
             let master_fingerprint = xpriv.fingerprint(&secp);
 
             let temp_wallet = Wallet::new_offline(

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -226,7 +226,7 @@ pub fn run_init(wallet_dir: &std::path::Path, cmd: InitOpt) -> anyhow::Result<Cm
             let bip85_key = xpriv
                 .derive_priv(
                     &secp,
-                    &DerivationPath::from_str("m/83696968'/128169'/64'/330'").unwrap(),
+                    &DerivationPath::from_str("m/83696968'/128169'/64'/0'").unwrap(),
                 )
                 .unwrap();
 

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -1,11 +1,11 @@
 use crate::{
+    bip85::get_bip85_bytes,
     cmd::{self},
     config::{Config, GunSigner},
 };
 use anyhow::{anyhow, Context};
 use bdk::{
     bitcoin::{
-        hashes::{sha512, Hash, HashEngine, Hmac, HmacEngine},
         secp256k1::Secp256k1,
         util::bip32::{DerivationPath, ExtendedPrivKey},
         Network,
@@ -220,27 +220,16 @@ pub fn run_init(wallet_dir: &std::path::Path, cmd: InitOpt) -> anyhow::Result<Cm
             };
 
             let seed_bytes = mnemonic.to_seed(passphrase);
-            // Create secret randomness from seed.
             let xpriv = ExtendedPrivKey::new_master(common_args.network, &seed_bytes).unwrap();
-            let secp = Secp256k1::signing_only();
-            let bip85_key = xpriv
-                .derive_priv(
-                    &secp,
-                    &DerivationPath::from_str("m/83696968'/128169'/64'/0'").unwrap(),
-                )
-                .unwrap();
 
-            let message = hex::decode(&format!("{}", bip85_key.private_key.display_secret()))?;
-            let mut engine = HmacEngine::<sha512::Hash>::new("bip-entropy-from-k".as_bytes());
-            engine.input(&message);
-            let hash = Hmac::<sha512::Hash>::from_engine(engine);
-
-            let hex_bip85_bytes = hash.to_string();
+            let bip85_bytes: [u8; 64] = get_bip85_bytes::<64>(
+                xpriv,
+                DerivationPath::from_str("m/83696968'/128169'/64'/330'").unwrap(),
+            );
             let secret_file = wallet_dir.join("secret_protocol_randomness");
-            fs::write(secret_file, hex_bip85_bytes)?;
+            fs::write(secret_file, hex::encode(&bip85_bytes))?;
 
             let secp = Secp256k1::signing_only();
-            let xpriv = ExtendedPrivKey::new_master(common_args.network, &seed_bytes).unwrap();
             let master_fingerprint = xpriv.fingerprint(&secp);
 
             let temp_wallet = Wallet::new_offline(

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -126,8 +126,7 @@ fn create_secret_randomness(wallet_dir: &std::path::Path) -> anyhow::Result<()> 
     rand::rngs::OsRng.fill_bytes(&mut random_bytes);
 
     let hex_randomness = hex::encode(&random_bytes);
-    let mut secret_file = wallet_dir.to_path_buf();
-    secret_file.push("secret_protocol_randomness");
+    let secret_file = wallet_dir.join("secret_protocol_randomness");
     fs::write(secret_file, hex_randomness)?;
     Ok(())
 }
@@ -237,8 +236,7 @@ pub fn run_init(wallet_dir: &std::path::Path, cmd: InitOpt) -> anyhow::Result<Cm
             let hash = Hmac::<sha512::Hash>::from_engine(engine);
 
             let hex_bip85_bytes = hash.to_string();
-            let mut secret_file = wallet_dir.to_path_buf();
-            secret_file.push("secret_protocol_randomness");
+            let secret_file = wallet_dir.join("secret_protocol_randomness");
             fs::write(secret_file, hex_bip85_bytes)?;
 
             let secp = Secp256k1::signing_only();

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -209,8 +209,7 @@ pub fn load_wallet(
             )),
             GunSigner::SeedWordsFile {
                 file_path,
-                has_passphrase,
-                master_fingerprint,
+                passphrase_fingerprint,
             } => {
                 let seed_words =
                     fs::read_to_string(file_path.clone()).context("loading seed words")?;
@@ -226,16 +225,15 @@ pub fn load_wallet(
                 let master_xpriv =
                     ExtendedPrivKey::new_master(config.network, &seed_bytes).unwrap();
 
-                if !has_passphrase {
-                    Arc::new(XKeySigner {
-                        master_xkey: master_xpriv,
-                    })
-                } else {
-                    Arc::new(PwSeedSigner {
+                match passphrase_fingerprint {
+                    Some(fingerprint) => Arc::new(PwSeedSigner {
                         mnemonic,
                         network: config.network,
-                        master_fingerprint: *master_fingerprint,
-                    })
+                        master_fingerprint: *fingerprint,
+                    }),
+                    None => Arc::new(XKeySigner {
+                        master_xkey: master_xpriv,
+                    }),
                 }
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod keychain;
 pub mod psbt_ext;
 pub mod signers;
 pub use fee_spec::*;
+pub mod bip85;
 
 pub use chacha20::cipher;
 pub use olivia_core::chrono;


### PR DESCRIPTION
Based on https://github.com/LLFourn/gun/pull/77 fixes https://github.com/LLFourn/gun/issues/46 https://github.com/LLFourn/gun/pull/58
Adds new `--has-passphrase` bool to `init seed`.
Passphrase validation (with external_descriptor) not fully implemented.