### PR TITLE
Secret randomness refactor

### DIFF
--- a/src/betting/bet_args.rs
+++ b/src/betting/bet_args.rs
@@ -1,4 +1,4 @@
-use crate::{betting::*, ValueChoice};
+use crate::{betting::*, database::GunDatabase, ValueChoice};
 use anyhow::{anyhow, Context};
 use bdk::{
     bitcoin::Amount,
@@ -31,12 +31,12 @@ impl Default for BetArgs<'_, '_> {
 impl BetArgs<'_, '_> {
     pub fn apply_args<B, D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>, Ctx: TxBuilderContext>(
         &self,
-        bet_db: &BetDatabase,
+        gun_db: &GunDatabase,
         builder: &mut TxBuilder<B, D, Cs, Ctx>,
     ) -> anyhow::Result<()> {
-        builder.unspendable(bet_db.currently_used_utxos(self.may_overlap)?);
+        builder.unspendable(gun_db.currently_used_utxos(self.may_overlap)?);
         for bet_id in self.must_overlap {
-            let bet = bet_db.get_entity::<BetState>(*bet_id)?.ok_or_else(|| {
+            let bet = gun_db.get_entity::<BetState>(*bet_id)?.ok_or_else(|| {
                 anyhow!("bet {} that we must overlap with does not exist", bet_id)
             })?;
             for input in bet.reserved_utxos() {

--- a/src/betting/mod.rs
+++ b/src/betting/mod.rs
@@ -1,25 +1,24 @@
 mod bet;
-mod database;
+mod bet_args;
 mod joint_output;
 mod offer;
-mod party;
 mod proposal;
 mod randomize;
+mod wallet_impls;
 mod witness;
 
 pub use bet::*;
-pub use database::*;
+pub use bet_args::*;
 pub use joint_output::*;
 pub use offer::*;
 use olivia_secp256k1::fun::{marker::EvenY, Point};
-pub use party::*;
 pub use proposal::*;
 pub use randomize::*;
 pub use witness::*;
 
-pub type OracleInfo = olivia_core::OracleInfo<olivia_secp256k1::Secp256k1>;
 pub type OracleEvent = olivia_core::OracleEvent<olivia_secp256k1::Secp256k1>;
 pub type Attestation = olivia_core::Attestation<olivia_secp256k1::Secp256k1>;
 pub type EventResponse = olivia_core::http::EventResponse<olivia_secp256k1::Secp256k1>;
 
 pub type PublicKey = Point<EvenY>;
+pub type BetId = u32;

--- a/src/betting/wallet_impls/mod.rs
+++ b/src/betting/wallet_impls/mod.rs
@@ -1,0 +1,5 @@
+mod offer;
+mod proposal;
+mod spend_won;
+mod state_machine;
+mod take_offer;

--- a/src/betting/wallet_impls/proposal.rs
+++ b/src/betting/wallet_impls/proposal.rs
@@ -1,22 +1,20 @@
-use crate::{betting::*, change::Change, ValueChoice};
+use crate::{betting::*, change::Change, keychain::Keychain, wallet::GunWallet, ValueChoice};
 use anyhow::{anyhow, Context};
 use bdk::{
     bitcoin::{Amount, Script},
-    database::BatchDatabase,
     wallet::coin_selection::LargestFirstCoinSelection,
     FeeRate,
 };
 use olivia_core::{OracleEvent, OracleId};
 use olivia_secp256k1::Secp256k1;
 
-use super::BetArgs;
-
-impl<D: BatchDatabase> Party<bdk::blockchain::EsploraBlockchain, D> {
+impl GunWallet {
     pub fn make_proposal(
         &self,
         oracle_id: OracleId,
         oracle_event: OracleEvent<Secp256k1>,
         args: BetArgs,
+        keychain: &Keychain,
     ) -> anyhow::Result<LocalProposal> {
         let event_id = &oracle_event.event.id;
         if event_id.n_outcomes() != 2 {
@@ -27,7 +25,7 @@ impl<D: BatchDatabase> Party<bdk::blockchain::EsploraBlockchain, D> {
         }
 
         let mut builder = self
-            .wallet
+            .bdk_wallet()
             .build_tx()
             .coin_selection(LargestFirstCoinSelection);
         // we use a 0 feerate because the offerer will pay the fee
@@ -40,7 +38,7 @@ impl<D: BatchDatabase> Party<bdk::blockchain::EsploraBlockchain, D> {
             }
         };
 
-        args.apply_args(self.bet_db(), &mut builder)?;
+        args.apply_args(self.gun_db(), &mut builder)?;
 
         let (psbt, txdetails) = builder
             .finish()
@@ -96,7 +94,7 @@ impl<D: BatchDatabase> Party<bdk::blockchain::EsploraBlockchain, D> {
             change_script: change.as_ref().map(|x| x.binscript().clone()),
         };
 
-        let keypair = self.keychain.get_key_for_proposal(&proposal);
+        let keypair = keychain.get_key_for_proposal(&proposal);
         proposal.public_key = keypair.public_key;
 
         let local_proposal = LocalProposal {

--- a/src/betting/wallet_impls/take_offer.rs
+++ b/src/betting/wallet_impls/take_offer.rs
@@ -1,11 +1,10 @@
-use crate::betting::*;
+use crate::{betting::*, keychain::Keychain, wallet::GunWallet, OracleInfo};
 use anyhow::{anyhow, Context};
 use bdk::{
     bitcoin::{
         util::psbt::{self, PartiallySignedTransaction as Psbt},
         Amount,
     },
-    database::BatchDatabase,
     miniscript::DescriptorTrait,
     wallet::tx_builder::TxOrdering,
     SignOptions,
@@ -14,20 +13,21 @@ use chacha20::ChaCha20Rng;
 use olivia_secp256k1::fun::{marker::EvenY, Point};
 use std::convert::TryInto;
 
-impl<D: BatchDatabase> Party<bdk::blockchain::EsploraBlockchain, D> {
+impl GunWallet {
     pub fn decrypt_offer(
         &self,
         bet_id: BetId,
         encrypted_offer: Ciphertext,
+        keychain: &Keychain,
     ) -> anyhow::Result<(Plaintext, Point<EvenY>, ChaCha20Rng)> {
         let local_proposal = self
-            .bet_db
+            .gun_db()
             .get_entity(bet_id)?
             .ok_or(anyhow!("Proposal does not exist"))?;
 
         match local_proposal {
             BetState::Proposed { local_proposal } => {
-                let keypair = self.keychain.get_key_for_proposal(&local_proposal.proposal);
+                let keypair = keychain.get_key_for_proposal(&local_proposal.proposal);
                 let (mut cipher, rng) = crate::ecdh::ecdh(&keypair, &encrypted_offer.public_key);
                 let plaintext = encrypted_offer.decrypt(&mut cipher)?;
 
@@ -58,13 +58,14 @@ impl<D: BatchDatabase> Party<bdk::blockchain::EsploraBlockchain, D> {
         offer: Offer,
         offer_public_key: Point<EvenY>,
         mut rng: ChaCha20Rng,
+        keychain: &Keychain,
     ) -> anyhow::Result<ValidatedOffer> {
         let (offer_psbt_inputs, offer_input_value) = self.lookup_offer_inputs(&offer)?;
 
         let randomize = Randomize::new(&mut rng);
 
         let bet_state = self
-            .bet_db
+            .gun_db()
             .get_entity::<BetState>(bet_id)?
             .ok_or(anyhow!("Bet {} doesn't exist", bet_id))?;
         let local_proposal = match bet_state {
@@ -78,11 +79,11 @@ impl<D: BatchDatabase> Party<bdk::blockchain::EsploraBlockchain, D> {
             ..
         } = local_proposal;
 
-        let keypair = self.keychain.get_key_for_proposal(&proposal);
+        let keypair = keychain.get_key_for_proposal(&proposal);
         let oracle_id = &proposal.oracle;
 
         let oracle_info = self
-            .bet_db
+            .gun_db()
             .get_entity::<OracleInfo>(oracle_id.clone())?
             .ok_or(anyhow!("Oracle {} isn't in the database", oracle_id))?;
 
@@ -111,7 +112,7 @@ impl<D: BatchDatabase> Party<bdk::blockchain::EsploraBlockchain, D> {
             .expect("we've checked the offer value on the chain");
         let joint_output_script_pubkey = joint_output.descriptor().script_pubkey();
 
-        let mut builder = self.wallet.build_tx();
+        let mut builder = self.bdk_wallet().build_tx();
 
         builder
             .manually_selected_only()
@@ -197,7 +198,7 @@ impl<D: BatchDatabase> Party<bdk::blockchain::EsploraBlockchain, D> {
     pub fn sign_validated_offer(&self, offer: &mut ValidatedOffer) -> anyhow::Result<()> {
         let psbt = &mut offer.bet.psbt;
         let is_final = self
-            .wallet
+            .bdk_wallet()
             .sign(psbt, SignOptions::default())
             .context("Failed to sign transaction")?;
 
@@ -211,7 +212,7 @@ impl<D: BatchDatabase> Party<bdk::blockchain::EsploraBlockchain, D> {
         &self,
         ValidatedOffer { bet_id, bet, .. }: ValidatedOffer,
     ) -> anyhow::Result<Psbt> {
-        self.bet_db
+        self.gun_db()
             .update_bets(&[bet_id], |bet_state, _, _| match bet_state {
                 BetState::Proposed { .. } => Ok(BetState::Included {
                     bet: bet.clone(),

--- a/src/bin/gun.rs
+++ b/src/bin/gun.rs
@@ -1,4 +1,5 @@
 use anyhow::anyhow;
+use bdk::blockchain::esplora::EsploraBlockchainConfig;
 use gun_wallet::cmd::{
     self, bet::BetOpt, AddressOpt, InitOpt, SendOpt, SplitOpt, TransactionOpt, UtxoOpt,
 };
@@ -64,7 +65,18 @@ fn main() -> anyhow::Result<()> {
             use Commands::*;
 
             if let Balance | Address(_) | Send(_) | Tx(_) | Utxo(_) = opt.command {
-                eprintln!("syncing wallet with {:?}", config.blockchain);
+                let EsploraBlockchainConfig {
+                    stop_gap,
+                    base_url,
+                    concurrency,
+                    ..
+                } = config.blockchain_config();
+                eprintln!(
+                    "syncing wallet with {} (stop_gap: {}, parallel_connections: {})",
+                    base_url,
+                    stop_gap,
+                    concurrency.unwrap_or(1)
+                );
                 wallet.sync()?;
             }
 

--- a/src/cmd/bet.rs
+++ b/src/cmd/bet.rs
@@ -2,16 +2,18 @@ use super::{read_input, run_oralce_cmd, Cell};
 use crate::{
     betting::*,
     cmd::{self, read_yn, sanitize_str, CmdOutput},
+    database::GunDatabase,
     item,
     keychain::Keychain,
     psbt_ext::PsbtFeeRate,
-    Url, ValueChoice,
+    wallet::GunWallet,
+    OracleInfo, Url, ValueChoice,
 };
 use anyhow::{anyhow, Context};
 use bdk::bitcoin::{Address, Amount, Script};
 use chacha20::cipher::StreamCipher;
 use olivia_core::{chrono::Utc, Outcome, OutcomeError};
-use std::{path::Path, str::FromStr};
+use std::str::FromStr;
 use structopt::StructOpt;
 
 #[derive(Clone, Debug, structopt::StructOpt)]
@@ -203,12 +205,16 @@ pub enum TagOpt {
     },
 }
 
-pub fn run_bet_cmd(wallet_dir: &Path, cmd: BetOpt, sync: bool) -> anyhow::Result<cmd::CmdOutput> {
+pub fn run_bet_cmd(
+    wallet: &GunWallet,
+    keychain: &Keychain,
+    cmd: BetOpt,
+    sync: bool,
+) -> anyhow::Result<cmd::CmdOutput> {
     // For now just always do this but we may want to do something more fine grained later.
     if sync {
-        let party = cmd::load_party(wallet_dir)?;
-        party.sync()?;
-        party.poke_bets();
+        wallet.sync()?;
+        wallet.poke_bets();
     }
 
     match cmd {
@@ -217,11 +223,10 @@ pub fn run_bet_cmd(wallet_dir: &Path, cmd: BetOpt, sync: bool) -> anyhow::Result
             event_url,
             yes,
         } => {
-            let party = cmd::load_party(wallet_dir)?;
             let oracle_id = event_url.host_str().unwrap().to_string();
             let now = Utc::now().naive_utc();
             let (oracle_event, _, is_attested) =
-                get_oracle_event_from_url(party.bet_db(), event_url)?;
+                get_oracle_event_from_url(wallet.gun_db(), event_url)?;
             if is_attested {
                 return Err(anyhow!("{} already attested", oracle_event.event.id));
             }
@@ -247,15 +252,15 @@ pub fn run_bet_cmd(wallet_dir: &Path, cmd: BetOpt, sync: bool) -> anyhow::Result
             }
             question += " Ok";
             let args = args.prompt_to_core_bet_args(None);
-            let local_proposal = party.make_proposal(oracle_id, oracle_event, args)?;
+            let local_proposal = wallet.make_proposal(oracle_id, oracle_event, args, keychain)?;
             if let Some(change) = &local_proposal.change {
                 eprintln!("This proposal will put {} “in-use” unnecessarily because the bet value {} does not match a sum of available utxos.\nYou can get a utxo with the exact amount using `gun split` first.\n--",  change.value(), local_proposal.proposal.value);
             }
 
             if yes || read_yn(&question) {
                 let proposal_string = local_proposal.proposal.clone().into_versioned().to_string();
-                let id = party
-                    .bet_db()
+                let id = wallet
+                    .gun_db()
                     .insert_bet(BetState::Proposed { local_proposal })?;
 
                 eprintln!("post your proposal and let people make offers to it:");
@@ -276,7 +281,6 @@ pub fn run_bet_cmd(wallet_dir: &Path, cmd: BetOpt, sync: bool) -> anyhow::Result
             pad,
             message,
         } => {
-            let party = cmd::load_party(wallet_dir)?;
             let proposal: Proposal = proposal.into();
             let event_id = proposal.event_id.clone();
             let now = Utc::now().naive_utc();
@@ -293,7 +297,7 @@ pub fn run_bet_cmd(wallet_dir: &Path, cmd: BetOpt, sync: bool) -> anyhow::Result
                 Url::parse(&format!("https://{}{}", proposal.oracle, proposal.event_id))?;
 
             let (oracle_event, oracle_info, is_attested) =
-                get_oracle_event_from_url(party.bet_db(), event_url)?;
+                get_oracle_event_from_url(wallet.gun_db(), event_url)?;
 
             if is_attested {
                 return Err(anyhow!("{} already attested", oracle_event.event.id));
@@ -355,17 +359,18 @@ pub fn run_bet_cmd(wallet_dir: &Path, cmd: BetOpt, sync: bool) -> anyhow::Result
 
             let args = args.prompt_to_core_bet_args(Some(proposal.value));
 
-            let (bet, local_public_key, mut cipher) = party.generate_offer_with_oracle_event(
+            let (bet, local_public_key, mut cipher) = wallet.generate_offer_with_oracle_event(
                 proposal,
                 outcome.value == 1,
                 oracle_event,
                 oracle_info,
                 args,
                 fee_args.fee,
+                keychain,
             )?;
 
             if yes || cmd::read_yn(&bet_prompt(&bet, "offer", true)) {
-                let (id, encrypted_offer, _) = party.sign_save_and_encrypt_offer(
+                let (id, encrypted_offer, _) = wallet.sign_save_and_encrypt_offer(
                     bet,
                     message,
                     local_public_key,
@@ -395,8 +400,8 @@ pub fn run_bet_cmd(wallet_dir: &Path, cmd: BetOpt, sync: bool) -> anyhow::Result
             yes,
             print_tx,
         } => {
-            let party = cmd::load_party(wallet_dir)?;
-            let (plaintext, offer_public_key, rng) = party.decrypt_offer(id, encrypted_offer)?;
+            let (plaintext, offer_public_key, rng) =
+                wallet.decrypt_offer(id, encrypted_offer, keychain)?;
             match plaintext {
                 Plaintext::Offerv1 { offer, message } => {
                     if let Some(mut message) = message {
@@ -405,18 +410,18 @@ pub fn run_bet_cmd(wallet_dir: &Path, cmd: BetOpt, sync: bool) -> anyhow::Result
                         eprintln!("This message was attached to the offer:\n#### START MESSAGE ####\n{}\n#### END MESSAGE ####", message);
                     }
                     let mut validated_offer =
-                        party.validate_offer(id, offer, offer_public_key, rng)?;
+                        wallet.validate_offer(id, offer, offer_public_key, rng, keychain)?;
                     if yes || cmd::read_yn(&bet_prompt(&validated_offer.bet, "take", false)) {
-                        party.sign_validated_offer(&mut validated_offer)?;
+                        wallet.sign_validated_offer(&mut validated_offer)?;
                         let (output, txid) = cmd::decide_to_broadcast(
-                            party.wallet().network(),
-                            party.wallet().client(),
+                            wallet.bdk_wallet().network(),
+                            wallet.bdk_wallet().client(),
                             validated_offer.bet.psbt.clone(),
                             yes,
                             print_tx,
                         )?;
                         if txid.is_some() {
-                            party.set_offer_taken(validated_offer)?;
+                            wallet.set_offer_taken(validated_offer)?;
                         }
                         Ok(output)
                     } else {
@@ -435,20 +440,19 @@ pub fn run_bet_cmd(wallet_dir: &Path, cmd: BetOpt, sync: bool) -> anyhow::Result
             print_tx,
             yes,
         } => {
-            let party = cmd::load_party(wallet_dir)?;
-            let wallet = party.wallet();
-            match party.claim(fee_args.fee, bump_claiming)? {
+            let bdk_wallet = wallet.bdk_wallet();
+            match wallet.claim(fee_args.fee, bump_claiming)? {
                 Some((ids, claim_psbt)) => {
                     let (output, txid) = cmd::decide_to_broadcast(
-                        wallet.network(),
-                        wallet.client(),
+                        bdk_wallet.network(),
+                        bdk_wallet.client(),
                         claim_psbt,
                         yes,
                         print_tx,
                     )?;
                     if let Some(txid) = txid {
                         for id in ids {
-                            if let Err(e) = party.take_next_action(id, false) {
+                            if let Err(e) = wallet.take_next_action(id, false) {
                                 eprintln!("error updating state of bet {} after broadcasting claim tx {}: {}", id, txid, e);
                             }
                         }
@@ -463,38 +467,34 @@ pub fn run_bet_cmd(wallet_dir: &Path, cmd: BetOpt, sync: bool) -> anyhow::Result
             fee_args,
             yes,
             print_tx,
-        } => {
-            let party = cmd::load_party(wallet_dir)?;
-            Ok(match party.generate_cancel_tx(&ids, fee_args.fee)? {
-                Some(psbt) => {
-                    let (output, txid) = cmd::decide_to_broadcast(
-                        party.wallet().network(),
-                        party.wallet().client(),
-                        psbt,
-                        yes,
-                        print_tx,
-                    )?;
+        } => Ok(match wallet.generate_cancel_tx(&ids, fee_args.fee)? {
+            Some(psbt) => {
+                let (output, txid) = cmd::decide_to_broadcast(
+                    wallet.bdk_wallet().network(),
+                    wallet.bdk_wallet().client(),
+                    psbt,
+                    yes,
+                    print_tx,
+                )?;
 
-                    if let Some(txid) = txid {
-                        for id in ids {
-                            if let Err(e) = party.take_next_action(id, true) {
-                                eprintln!("error updating state of bet {} after broadcasting cancel tx: {}: {}", id, txid, e);
-                            }
+                if let Some(txid) = txid {
+                    for id in ids {
+                        if let Err(e) = wallet.take_next_action(id, true) {
+                            eprintln!("error updating state of bet {} after broadcasting cancel tx: {}: {}", id, txid, e);
                         }
                     }
-                    output
                 }
-                None => {
-                    eprintln!("no bets needed canceling");
-                    CmdOutput::None
-                }
-            })
-        }
+                output
+            }
+            None => {
+                eprintln!("no bets needed canceling");
+                CmdOutput::None
+            }
+        }),
         BetOpt::Forget { ids } => {
-            let bet_db = cmd::load_bet_db(wallet_dir)?;
             let mut to_remove = vec![];
             for id in ids {
-                match bet_db.get_entity::<BetState>(id) {
+                match wallet.gun_db().get_entity::<BetState>(id) {
                     Ok(Some(bet_state)) => match bet_state {
                         BetState::Proposed { local_proposal } => {
                             match local_proposal.oracle_event.event.expected_outcome_time {
@@ -519,7 +519,7 @@ pub fn run_bet_cmd(wallet_dir: &Path, cmd: BetOpt, sync: bool) -> anyhow::Result
             }
 
             for id in &to_remove {
-                let _ = bet_db.remove_entity::<BetState>(*id);
+                let _ = wallet.gun_db().remove_entity::<BetState>(*id);
             }
 
             Ok(CmdOutput::List(
@@ -527,9 +527,8 @@ pub fn run_bet_cmd(wallet_dir: &Path, cmd: BetOpt, sync: bool) -> anyhow::Result
             ))
         }
         BetOpt::Show { id, raw } => {
-            let party = cmd::load_party(wallet_dir)?;
-            let bet_db = party.bet_db();
-            let bet_state = bet_db
+            let gun_db = wallet.gun_db();
+            let bet_state = gun_db
                 .get_entity::<BetState>(id)?
                 .ok_or(anyhow!("Bet {} doesn't exist", id))?;
 
@@ -547,7 +546,7 @@ pub fn run_bet_cmd(wallet_dir: &Path, cmd: BetOpt, sync: bool) -> anyhow::Result
                     "oracle" => Cell::string(&local_proposal.proposal.oracle),
                     "outcome-time" => local_proposal.oracle_event.event.expected_outcome_time.map(Cell::datetime).unwrap_or(Cell::Empty),
                     "inputs" => Cell::List(local_proposal.proposal.inputs.clone().into_iter().map(Cell::string).collect()),
-                    "change-addr" => local_proposal.change.as_ref().and_then(|change| Address::from_script(change.script(), party.wallet().network())).map(Cell::string).unwrap_or(Cell::Empty),
+                    "change-addr" => local_proposal.change.as_ref().and_then(|change| Address::from_script(change.script(), wallet.bdk_wallet().network())).map(Cell::string).unwrap_or(Cell::Empty),
                     "change-value" => local_proposal.change.as_ref().map(|change| Cell::Amount(change.value())).unwrap_or(Cell::Empty),
                     "tags" => Cell::List(local_proposal.tags.iter().map(Cell::string).collect()),
                     "string" => Cell::string(local_proposal.proposal.into_versioned()),
@@ -576,14 +575,8 @@ pub fn run_bet_cmd(wallet_dir: &Path, cmd: BetOpt, sync: bool) -> anyhow::Result
                 },
             })
         }
-        BetOpt::List => {
-            let bet_db = cmd::load_bet_db(wallet_dir)?;
-            Ok(list_bets(&bet_db))
-        }
-        BetOpt::Oracle(oracle_cmd) => {
-            let bet_db = cmd::load_bet_db(wallet_dir)?;
-            run_oralce_cmd(bet_db, oracle_cmd)
-        }
+        BetOpt::List => Ok(list_bets(wallet.gun_db())),
+        BetOpt::Oracle(oracle_cmd) => run_oralce_cmd(wallet.gun_db(), oracle_cmd),
         BetOpt::Inspect(inspect_cmd) => Ok(match inspect_cmd {
             InspectOpt::Proposal {
                 proposal:
@@ -607,24 +600,24 @@ pub fn run_bet_cmd(wallet_dir: &Path, cmd: BetOpt, sync: bool) -> anyhow::Result
                 id,
                 encrypted_offer,
             } => {
-                let party = cmd::load_party(wallet_dir)?;
-                let bet_state = party
-                    .bet_db()
+                let bet_state = wallet
+                    .gun_db()
                     .get_entity::<BetState>(id)?
                     .ok_or(anyhow!("unknown bet id {}", id))?;
                 match bet_state {
                     BetState::Proposed { local_proposal } => {
                         let event_id = &local_proposal.oracle_event.event.id;
                         let (plaintext, offer_public_key, rng) =
-                            party.decrypt_offer(id, encrypted_offer)?;
+                            wallet.decrypt_offer(id, encrypted_offer, keychain)?;
 
                         match plaintext {
                             Plaintext::Offerv1 { offer, message } => {
-                                let (fee, feerate, valid) = match party.validate_offer(
+                                let (fee, feerate, valid) = match wallet.validate_offer(
                                     id,
                                     offer.clone(),
                                     offer_public_key,
                                     rng,
+                                    keychain,
                                 ) {
                                     Ok(validated_offer) => {
                                         let (fee, feerate, _) = validated_offer.bet.psbt.fee();
@@ -672,17 +665,17 @@ pub fn run_bet_cmd(wallet_dir: &Path, cmd: BetOpt, sync: bool) -> anyhow::Result
             }
         }),
         BetOpt::Tag(tagopt) => {
-            let bet_db = cmd::load_bet_db(wallet_dir)?;
+            let gun_db = wallet.gun_db();
             match tagopt {
                 TagOpt::Add { id, tag } => {
-                    bet_db.update_bets(&[id], |mut bet_state, _, _| {
+                    gun_db.update_bets(&[id], |mut bet_state, _, _| {
                         bet_state.tags_mut().push(tag.clone());
                         Ok(bet_state)
                     })?;
                     Ok(CmdOutput::None)
                 }
                 TagOpt::Remove { id, tag } => {
-                    bet_db.update_bets(&[id], |mut bet_state, _, _| {
+                    gun_db.update_bets(&[id], |mut bet_state, _, _| {
                         bet_state
                             .tags_mut()
                             .retain(|existing_tag| existing_tag != &tag);
@@ -704,8 +697,7 @@ pub fn run_bet_cmd(wallet_dir: &Path, cmd: BetOpt, sync: bool) -> anyhow::Result
                 std::io::stdin().read_to_string(&mut words).unwrap();
                 words
             });
-            let party = cmd::load_party(wallet_dir)?;
-            let (ciphertext, mut cipher) = reply(&party.keychain, proposal, message);
+            let (ciphertext, mut cipher) = reply(keychain, proposal, message);
             let (ciphertext_str, overflow) = ciphertext.to_string_padded(pad, &mut cipher);
             if overflow > 0 && pad != 0 {
                 eprintln!(
@@ -738,7 +730,7 @@ fn reply(
     (ciphertext, cipher)
 }
 
-fn list_bets(bet_db: &BetDatabase) -> CmdOutput {
+fn list_bets(bet_db: &GunDatabase) -> CmdOutput {
     let mut rows = vec![];
 
     for (id, bet_state) in bet_db.list_entities_print_error::<BetState>() {
@@ -815,7 +807,7 @@ fn list_bets(bet_db: &BetDatabase) -> CmdOutput {
 }
 
 fn get_oracle_event_from_url(
-    bet_db: &BetDatabase,
+    bet_db: &GunDatabase,
     url: Url,
 ) -> anyhow::Result<(OracleEvent, OracleInfo, bool)> {
     let oracle_id = url.host_str().ok_or(anyhow!("url {} missing host", url))?;

--- a/src/cmd/bet.rs
+++ b/src/cmd/bet.rs
@@ -730,10 +730,10 @@ fn reply(
     (ciphertext, cipher)
 }
 
-fn list_bets(bet_db: &GunDatabase) -> CmdOutput {
+fn list_bets(gun_db: &GunDatabase) -> CmdOutput {
     let mut rows = vec![];
 
-    for (id, bet_state) in bet_db.list_entities_print_error::<BetState>() {
+    for (id, bet_state) in gun_db.list_entities_print_error::<BetState>() {
         let name = String::from(bet_state.name());
         match bet_state.into_bet_or_prop() {
             BetOrProp::Proposal(local_proposal) => rows.push(vec![
@@ -807,7 +807,7 @@ fn list_bets(bet_db: &GunDatabase) -> CmdOutput {
 }
 
 fn get_oracle_event_from_url(
-    bet_db: &GunDatabase,
+    gun_db: &GunDatabase,
     url: Url,
 ) -> anyhow::Result<(OracleEvent, OracleInfo, bool)> {
     let oracle_id = url.host_str().ok_or(anyhow!("url {} missing host", url))?;
@@ -823,7 +823,7 @@ fn get_oracle_event_from_url(
             )
         })?;
 
-    let oracle_info = bet_db
+    let oracle_info = gun_db
         .get_entity::<OracleInfo>(oracle_id.to_string())?
         .ok_or(anyhow!(
             "oracle '{}' is not trusted -- run `gun bet oracle add '{}' to trust it",

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -272,8 +272,8 @@ pub fn run_init(wallet_dir: &std::path::Path, cmd: InitOpt) -> anyhow::Result<Cm
             )?;
 
             let signers = match psbt_signer_dir {
-                Some(psbt_signer_dir) => {
-                    vec![GunSigner::PsbtSdCard { psbt_signer_dir }]
+                Some(path) => {
+                    vec![GunSigner::PsbtDir { path }]
                 }
                 None => {
                     vec![]
@@ -305,12 +305,8 @@ pub fn run_init(wallet_dir: &std::path::Path, cmd: InitOpt) -> anyhow::Result<Cm
             )?;
 
             let signers = match psbt_signer_dir {
-                Some(psbt_signer_dir) => {
-                    vec![GunSigner::PsbtSdCard { psbt_signer_dir }]
-                }
-                None => {
-                    vec![]
-                }
+                Some(path) => vec![GunSigner::PsbtDir { path }],
+                None => vec![],
             };
 
             Config {
@@ -381,8 +377,8 @@ pub fn run_init(wallet_dir: &std::path::Path, cmd: InitOpt) -> anyhow::Result<Cm
                 "wpkh([{}/84'/0'/0']{}/1/*)",
                 &wallet_export.xfp, &wallet_export.bip84.xpub
             );
-            let signers = vec![GunSigner::PsbtSdCard {
-                psbt_signer_dir: coldcard_sd_dir,
+            let signers = vec![GunSigner::PsbtDir {
+                path: coldcard_sd_dir,
             }];
 
             Config {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -16,7 +16,7 @@ use bdk::{
         },
         Address, Amount, Network, Txid,
     },
-    blockchain::{AnyBlockchain, ConfigurableBlockchain},
+    blockchain::{ConfigurableBlockchain, EsploraBlockchain},
     database::BatchDatabase,
     signer::Signer,
     sled,
@@ -34,14 +34,13 @@ pub use wallet::*;
 
 use crate::{
     chrono::NaiveDateTime,
-    config::{Config, ConfigV0, VersionedConfig},
+    config::{Config, VersionedConfig},
     database::GunDatabase,
     keychain::Keychain,
     psbt_ext::PsbtFeeRate,
     FeeSpec, ValueChoice,
 };
 use anyhow::anyhow;
-use olivia_secp256k1::fun::hex;
 use std::{
     collections::HashMap,
     fs,
@@ -72,10 +71,9 @@ pub fn load_config(wallet_dir: &std::path::Path) -> anyhow::Result<Config> {
     match config_file.exists() {
         true => {
             let json_config = fs::read_to_string(config_file.clone())?;
-            Ok(match serde_json::from_str::<ConfigV0>(&json_config) {
-                Ok(configv0) => configv0.into_v1(wallet_dir)?,
-                Err(_) => serde_json::from_str::<VersionedConfig>(&json_config)?.into(),
-            })
+            Ok(serde_json::from_str::<VersionedConfig>(&json_config)
+                .context("Perhaps you are trying to load an old config?")?
+                .into())
         }
         false => {
             return Err(anyhow!(
@@ -130,27 +128,6 @@ pub fn get_seed_words_file(wallet_dir: &Path) -> PathBuf {
     seed_words_file
 }
 
-pub fn load_protocol_keychain(wallet_dir: &Path) -> anyhow::Result<[u8; 64]> {
-    let mut secret_randomness_file = wallet_dir.to_path_buf();
-    secret_randomness_file.push("secret_protocol_randomness");
-    let hex_randomness =
-        fs::read_to_string(secret_randomness_file.clone()).context("loading secret randomness")?;
-    let mut byte_randomness = [0u8; 64];
-    byte_randomness.copy_from_slice(&hex::decode(&hex_randomness).expect(&format!(
-        "Decoding hex in secret protocol randomness {}",
-        secret_randomness_file.display()
-    )));
-    Ok(byte_randomness)
-}
-
-pub fn load_gun_db(wallet_dir: &Path) -> anyhow::Result<GunDatabase> {
-    let mut db_file = wallet_dir.to_path_buf();
-    db_file.push("database.sled");
-    let database = sled::open(db_file.to_str().unwrap())?;
-    let bet_db = GunDatabase::new(database.open_tree("bets")?);
-    Ok(bet_db)
-}
-
 pub fn load_wallet(
     wallet_dir: &std::path::Path,
 ) -> anyhow::Result<(GunWallet, Option<Keychain>, Config)> {
@@ -174,11 +151,7 @@ pub fn load_wallet(
         .open_tree("wallet")
         .context("opening wallet tree")?;
 
-    let esplora = match AnyBlockchain::from_config(&config.blockchain)? {
-        AnyBlockchain::Esplora(esplora) => esplora,
-        #[allow(unreachable_patterns)]
-        _ => return Err(anyhow!("At the moment only esplora is supported")),
-    };
+    let esplora = EsploraBlockchain::from_config(config.blockchain_config())?;
 
     let mut wallet = Wallet::new(
         &config.descriptor_external,

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -2,7 +2,9 @@ mod init;
 mod oracle;
 use crate::{
     config::GunSigner,
+    keychain::ProtocolSecret,
     signers::{PsbtDirSigner, PwSeedSigner, XKeySigner},
+    wallet::GunWallet,
 };
 mod wallet;
 use anyhow::Context;
@@ -14,7 +16,7 @@ use bdk::{
         },
         Address, Amount, Network, Txid,
     },
-    blockchain::{AnyBlockchain, ConfigurableBlockchain, EsploraBlockchain},
+    blockchain::{AnyBlockchain, ConfigurableBlockchain},
     database::BatchDatabase,
     signer::Signer,
     sled,
@@ -31,9 +33,9 @@ use term_table::{row::Row, Table};
 pub use wallet::*;
 
 use crate::{
-    betting::{BetDatabase, Party},
     chrono::NaiveDateTime,
     config::{Config, ConfigV0, VersionedConfig},
+    database::GunDatabase,
     keychain::Keychain,
     psbt_ext::PsbtFeeRate,
     FeeSpec, ValueChoice,
@@ -128,7 +130,7 @@ pub fn get_seed_words_file(wallet_dir: &Path) -> PathBuf {
     seed_words_file
 }
 
-pub fn get_secret_randomness(wallet_dir: &Path) -> anyhow::Result<[u8; 64]> {
+pub fn load_protocol_keychain(wallet_dir: &Path) -> anyhow::Result<[u8; 64]> {
     let mut secret_randomness_file = wallet_dir.to_path_buf();
     secret_randomness_file.push("secret_protocol_randomness");
     let hex_randomness =
@@ -141,30 +143,17 @@ pub fn get_secret_randomness(wallet_dir: &Path) -> anyhow::Result<[u8; 64]> {
     Ok(byte_randomness)
 }
 
-pub fn load_bet_db(wallet_dir: &Path) -> anyhow::Result<BetDatabase> {
+pub fn load_gun_db(wallet_dir: &Path) -> anyhow::Result<GunDatabase> {
     let mut db_file = wallet_dir.to_path_buf();
     db_file.push("database.sled");
     let database = sled::open(db_file.to_str().unwrap())?;
-    let bet_db = BetDatabase::new(database.open_tree("bets")?);
+    let bet_db = GunDatabase::new(database.open_tree("bets")?);
     Ok(bet_db)
-}
-
-pub fn load_party(
-    wallet_dir: &Path,
-) -> anyhow::Result<Party<bdk::blockchain::EsploraBlockchain, impl bdk::database::BatchDatabase>> {
-    let (wallet, bet_db, keychain, config) = load_wallet(wallet_dir).context("loading wallet")?;
-    let party = Party::new(wallet, bet_db, keychain, config.blockchain);
-    Ok(party)
 }
 
 pub fn load_wallet(
     wallet_dir: &std::path::Path,
-) -> anyhow::Result<(
-    Wallet<EsploraBlockchain, impl BatchDatabase>,
-    BetDatabase,
-    Keychain,
-    Config,
-)> {
+) -> anyhow::Result<(GunWallet, Option<Keychain>, Config)> {
     use bdk::keys::bip39::Mnemonic;
 
     if !wallet_dir.exists() {
@@ -191,7 +180,6 @@ pub fn load_wallet(
         _ => return Err(anyhow!("At the moment only esplora is supported")),
     };
 
-    let secret_randomness = get_secret_randomness(&wallet_dir)?;
     let mut wallet = Wallet::new(
         &config.descriptor_external,
         config.descriptor_internal.as_ref(),
@@ -246,9 +234,11 @@ pub fn load_wallet(
         );
     }
 
-    let bet_db = BetDatabase::new(database.open_tree("bets").context("opening bets tree")?);
+    let gun_db = GunDatabase::new(database.open_tree("gun").context("opening gun db tree")?);
+    let keychain = gun_db.get_entity::<ProtocolSecret>(())?.map(Keychain::from);
+    let gun_wallet = GunWallet::new(wallet, gun_db);
 
-    Ok((wallet, bet_db, Keychain::new(secret_randomness), config))
+    Ok((gun_wallet, keychain, config))
 }
 
 pub fn load_wallet_db(wallet_dir: &std::path::Path) -> anyhow::Result<impl BatchDatabase> {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -2,7 +2,7 @@ mod init;
 mod oracle;
 use crate::{
     config::GunSigner,
-    signers::{PwSeedSigner, SDCardSigner, XKeySigner},
+    signers::{PsbtDirSigner, PwSeedSigner, XKeySigner},
 };
 mod wallet;
 use anyhow::Context;
@@ -203,7 +203,9 @@ pub fn load_wallet(
 
     for (i, signer) in config.signers.iter().enumerate() {
         let signer: Arc<dyn Signer> = match signer {
-            GunSigner::PsbtSdCard { psbt_signer_dir } => Arc::new(SDCardSigner::create(
+            GunSigner::PsbtDir {
+                path: psbt_signer_dir,
+            } => Arc::new(PsbtDirSigner::create(
                 psbt_signer_dir.to_owned(),
                 config.network,
             )),

--- a/src/cmd/oracle.rs
+++ b/src/cmd/oracle.rs
@@ -1,7 +1,4 @@
-use crate::{
-    betting::{BetDatabase, OracleInfo},
-    cmd, item, Url,
-};
+use crate::{cmd, database::GunDatabase, item, OracleInfo, Url};
 use anyhow::anyhow;
 use olivia_core::{http::RootResponse, OracleId};
 use olivia_secp256k1::Secp256k1;
@@ -34,7 +31,7 @@ pub enum OracleOpt {
     },
 }
 
-pub fn run_oralce_cmd(bet_db: BetDatabase, cmd: OracleOpt) -> anyhow::Result<CmdOutput> {
+pub fn run_oralce_cmd(bet_db: &GunDatabase, cmd: OracleOpt) -> anyhow::Result<CmdOutput> {
     match cmd {
         OracleOpt::Add { url, yes } => {
             let url =

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,8 +32,8 @@ pub enum GunSigner {
         #[serde(skip_serializing_if = "Option::is_none")]
         passphrase_fingerprint: Option<Fingerprint>,
     },
-    PsbtSdCard {
-        psbt_signer_dir: PathBuf,
+    PsbtDir {
+        path: PathBuf,
     },
 }
 

--- a/src/keychain.rs
+++ b/src/keychain.rs
@@ -1,13 +1,21 @@
 use crate::betting::Proposal;
-use bdk::bitcoin::{
-    hashes::{sha512, Hash, HashEngine, Hmac, HmacEngine},
-    util::bip32::ExtendedPrivKey,
-    Network,
-};
+use bdk::bitcoin::hashes::{sha512, Hash, HashEngine, Hmac, HmacEngine};
 use olivia_secp256k1::schnorr_fun::fun::{marker::*, Point, Scalar, G};
 
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum ProtocolSecret {
+    Bytes(#[serde(with = "crate::serde_hacks::BigArray")] [u8; 64]),
+}
+
+impl From<ProtocolSecret> for Keychain {
+    fn from(protocol_secret: ProtocolSecret) -> Self {
+        match protocol_secret {
+            ProtocolSecret::Bytes(bytes) => Keychain::new(bytes),
+        }
+    }
+}
+
 pub struct Keychain {
-    seed: [u8; 64],
     proposal_hmac: HmacEngine<sha512::Hash>,
     offer_hmac: HmacEngine<sha512::Hash>,
 }
@@ -48,16 +56,13 @@ impl Keychain {
         };
 
         Self {
-            seed,
             proposal_hmac,
             offer_hmac,
         }
     }
 
-    pub fn main_wallet_xprv(&self, network: Network) -> ExtendedPrivKey {
-        ExtendedPrivKey::new_master(network, &self.seed).unwrap()
-    }
-
+    /// TODO: use the versioned proposal here
+    /// DONOTMERGE LIKE THIS
     pub fn get_key_for_proposal(&self, proposal: &Proposal) -> KeyPair {
         let mut proposal = proposal.clone();
         proposal.public_key = crate::placeholder_point();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,11 +16,16 @@ pub mod psbt_ext;
 pub mod signers;
 pub use fee_spec::*;
 pub mod bip85;
+pub mod database;
+mod serde_hacks;
+pub mod wallet;
 
 pub use chacha20::cipher;
 pub use olivia_core::chrono;
 pub use olivia_secp256k1::schnorr_fun::fun::{hex, rand_core};
 pub use url::Url;
+
+pub type OracleInfo = olivia_core::OracleInfo<olivia_secp256k1::Secp256k1>;
 
 #[derive(Clone, Debug)]
 pub enum ValueChoice {

--- a/src/serde_hacks.rs
+++ b/src/serde_hacks.rs
@@ -1,0 +1,68 @@
+use serde::{
+    de::{Deserialize, Deserializer, Error, SeqAccess, Visitor},
+    ser::{Serialize, SerializeTuple, Serializer},
+};
+use std::{fmt, marker::PhantomData};
+
+pub(crate) trait BigArray<'de>: Sized {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer;
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>;
+}
+
+macro_rules! big_array {
+    ($($len:expr,)+) => {
+        $(
+            impl<'de, T> BigArray<'de> for [T; $len]
+                where T: Default + Copy + Serialize + Deserialize<'de>
+            {
+                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                    where S: Serializer
+                {
+                    let mut seq = serializer.serialize_tuple(self.len())?;
+                    for elem in &self[..] {
+                        seq.serialize_element(elem)?;
+                    }
+                    seq.end()
+                }
+
+                fn deserialize<D>(deserializer: D) -> Result<[T; $len], D::Error>
+                    where D: Deserializer<'de>
+                {
+                    struct ArrayVisitor<T> {
+                        element: PhantomData<T>,
+                    }
+
+                    impl<'de, T> Visitor<'de> for ArrayVisitor<T>
+                        where T: Default + Copy + Deserialize<'de>
+                    {
+                        type Value = [T; $len];
+
+                        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                            formatter.write_str(concat!("an array of length ", $len))
+                        }
+
+                        fn visit_seq<A>(self, mut seq: A) -> Result<[T; $len], A::Error>
+                            where A: SeqAccess<'de>
+                        {
+                            let mut arr = [T::default(); $len];
+                            for i in 0..$len {
+                                arr[i] = seq.next_element()?
+                                    .ok_or_else(|| Error::invalid_length(i, &self))?;
+                            }
+                            Ok(arr)
+                        }
+                    }
+
+                    let visitor = ArrayVisitor { element: PhantomData };
+                    deserializer.deserialize_tuple($len, visitor)
+                }
+            }
+        )+
+    }
+}
+
+big_array! { 64, }

--- a/src/signers.rs
+++ b/src/signers.rs
@@ -128,21 +128,21 @@ impl Signer for PwSeedSigner {
 }
 
 #[derive(Debug)]
-pub struct SDCardSigner {
-    psbt_signer_dir: PathBuf,
+pub struct PsbtDirSigner {
+    path: PathBuf,
     network: Network,
 }
 
-impl SDCardSigner {
+impl PsbtDirSigner {
     pub fn create(psbt_signer_dir: PathBuf, network: Network) -> Self {
-        SDCardSigner {
-            psbt_signer_dir,
+        PsbtDirSigner {
+            path: psbt_signer_dir,
             network,
         }
     }
 }
 
-impl Signer for SDCardSigner {
+impl Signer for PsbtDirSigner {
     fn sign(
         &self,
         psbt: &mut PartiallySignedTransaction,
@@ -158,14 +158,14 @@ impl Signer for SDCardSigner {
 
         let txid = psbt.clone().extract_tx().txid();
         let psbt_file = self
-            .psbt_signer_dir
+            .path
             .as_path()
             .join(format!("{}.psbt", txid.to_string()));
         loop {
-            if !self.psbt_signer_dir.exists() {
+            if !self.path.exists() {
                 eprintln!(
-                    "psbt-output-dir '{}' does not exist (maybe you need to insert your SD card?).\nPress enter to try again.",
-                    self.psbt_signer_dir.display()
+                    "PSBT directory '{}' does not exist (maybe you need to insert your SD card?).\nPress enter to try again.",
+                    self.path.display()
                 );
                 let _ = std::io::stdin().read_line(&mut String::new());
             } else if let Err(e) = std::fs::write(&psbt_file, psbt.to_string()) {
@@ -183,11 +183,11 @@ impl Signer for SDCardSigner {
         eprintln!("Wrote PSBT to {}", psbt_file.display());
 
         let file_locations = [
-            self.psbt_signer_dir
+            self.path
                 .as_path()
                 .join(format!("{}-signed.psbt", txid))
                 .to_path_buf(),
-            self.psbt_signer_dir
+            self.path
                 .as_path()
                 .join(format!("{}-part.psbt", txid))
                 .to_path_buf(),

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,26 +1,16 @@
-mod bet_args;
-mod offer;
-mod proposal;
-mod spend_won;
-mod state_machine;
-mod take_offer;
-
-pub use bet_args::*;
 use miniscript::DescriptorTrait;
 
-use crate::{betting::*, keychain::Keychain, FeeSpec};
+use crate::{betting::*, database::GunDatabase, FeeSpec, OracleInfo};
 use anyhow::{anyhow, Context};
 use bdk::{
     bitcoin::{
         util::psbt::{self, PartiallySignedTransaction as Psbt},
-        OutPoint, Txid,
+        OutPoint,
     },
-    blockchain::{
-        noop_progress, AnyBlockchain, AnyBlockchainConfig, Blockchain, ConfigurableBlockchain,
-    },
-    database::MemoryDatabase,
-    descriptor::ExtendedDescriptor,
-    wallet::{AddressIndex, Wallet},
+    blockchain::{noop_progress, Blockchain, EsploraBlockchain},
+    database::Database,
+    sled,
+    wallet::AddressIndex,
     KeychainKind, SignOptions,
 };
 use olivia_core::{Attestation, Outcome};
@@ -29,47 +19,37 @@ use olivia_secp256k1::{
     Secp256k1,
 };
 
-pub struct Party<B, D> {
-    wallet: Wallet<B, D>,
-    pub(crate) keychain: Keychain,
+type BdkWallet = bdk::Wallet<EsploraBlockchain, sled::Tree>;
+
+pub struct GunWallet {
+    wallet: BdkWallet,
     client: ureq::Agent,
-    bet_db: BetDatabase,
-    blockchain_config: AnyBlockchainConfig,
+    bet_db: GunDatabase,
 }
 
-impl<D> Party<bdk::blockchain::EsploraBlockchain, D>
-where
-    D: bdk::database::BatchDatabase,
-{
-    pub fn new(
-        wallet: Wallet<bdk::blockchain::EsploraBlockchain, D>,
-        bet_db: BetDatabase,
-        keychain: Keychain,
-        blockchain_config: AnyBlockchainConfig,
-    ) -> Self {
+impl GunWallet {
+    pub fn new(wallet: BdkWallet, bet_db: GunDatabase) -> Self {
         Self {
             wallet,
-            keychain,
             bet_db,
             client: ureq::Agent::new(),
-            blockchain_config,
         }
     }
 
-    pub fn wallet(&self) -> &Wallet<bdk::blockchain::EsploraBlockchain, D> {
+    pub fn bdk_wallet(&self) -> &BdkWallet {
         &self.wallet
     }
 
-    pub fn bet_db(&self) -> &BetDatabase {
+    pub fn gun_db(&self) -> &GunDatabase {
         &self.bet_db
+    }
+
+    pub fn http_client(&self) -> &ureq::Agent {
+        &self.client
     }
 
     pub fn trust_oracle(&self, oracle_info: OracleInfo) -> anyhow::Result<()> {
         self.bet_db.insert_oracle_info(oracle_info)
-    }
-
-    pub fn new_blockchain(&self) -> anyhow::Result<AnyBlockchain> {
-        Ok(AnyBlockchain::from_config(&self.blockchain_config)?)
     }
 
     pub fn learn_outcome(
@@ -145,7 +125,7 @@ where
         let mut utxos_that_need_canceling: Vec<OutPoint> = vec![];
 
         for bet_id in bet_ids {
-            let bet_state = self.bet_db().get_entity(*bet_id)?.ok_or(anyhow!(
+            let bet_state = self.gun_db().get_entity(*bet_id)?.ok_or(anyhow!(
                 "can't cancel bet {} because it doesn't exist",
                 bet_id
             ))?;
@@ -203,7 +183,7 @@ where
             }
         }
 
-        let mut builder = self.wallet.build_tx();
+        let mut builder = self.bdk_wallet().build_tx();
         builder
             .manually_selected_only()
             .enable_rbf()
@@ -213,7 +193,7 @@ where
         for utxo in utxos_that_need_canceling {
             // we have to add these as foreign UTXOs because BDK doesn't let you spend
             // outputs that have been spent by tx in the mempool.
-            let tx = match self.wallet.query_db(|db| db.get_tx(&utxo.txid, true))? {
+            let tx = match self.bdk_wallet().database().get_tx(&utxo.txid, true)? {
                 Some(tx) => tx,
                 None => {
                     debug_assert!(false, "we should always be able to find our tx");
@@ -254,30 +234,6 @@ where
         Ok(Some(psbt))
     }
 
-    pub fn is_confirmed(
-        &self,
-        txid: Txid,
-        // output in transaction
-        descriptor: ExtendedDescriptor,
-    ) -> anyhow::Result<Option<u32>> {
-        let blockchain = self.new_blockchain()?;
-        let wallet = Wallet::new(
-            descriptor,
-            None,
-            self.wallet.network(),
-            MemoryDatabase::default(),
-            blockchain,
-        )?;
-        wallet.sync(bdk::blockchain::noop_progress(), None)?;
-        Ok(wallet
-            .list_transactions(true)?
-            .iter()
-            .find_map(|tx| match &tx.confirmation_time {
-                Some(confirmation_time) if tx.txid == txid => Some(confirmation_time.height),
-                _ => None,
-            }))
-    }
-
     // the reason we require p2wpkh inputs here is so the witness is non-malleable.
     // What to do about TR outputs in the future I haven't decided.
     pub fn p2wpkh_outpoint_to_psbt_input(&self, outpoint: OutPoint) -> anyhow::Result<psbt::Input> {
@@ -311,13 +267,13 @@ where
 
     // convenience methods
     pub fn sync(&self) -> anyhow::Result<()> {
-        eprintln!("syncing wallet with {:?}", self.blockchain_config);
+        eprintln!("syncing wallet...");
         self.wallet.sync(noop_progress(), None)?;
         Ok(())
     }
 
     pub fn poke_bets(&self) {
-        for (bet_id, _) in self.bet_db().list_entities_print_error::<BetState>() {
+        for (bet_id, _) in self.gun_db().list_entities_print_error::<BetState>() {
             match self.take_next_action(bet_id, true) {
                 Ok(_updated) => {}
                 Err(e) => eprintln!("Error trying to take action on bet {}: {:?}", bet_id, e),

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -24,14 +24,14 @@ type BdkWallet = bdk::Wallet<EsploraBlockchain, sled::Tree>;
 pub struct GunWallet {
     wallet: BdkWallet,
     client: ureq::Agent,
-    bet_db: GunDatabase,
+    db: GunDatabase,
 }
 
 impl GunWallet {
-    pub fn new(wallet: BdkWallet, bet_db: GunDatabase) -> Self {
+    pub fn new(wallet: BdkWallet, db: GunDatabase) -> Self {
         Self {
             wallet,
-            bet_db,
+            db,
             client: ureq::Agent::new(),
         }
     }
@@ -41,15 +41,11 @@ impl GunWallet {
     }
 
     pub fn gun_db(&self) -> &GunDatabase {
-        &self.bet_db
+        &self.db
     }
 
     pub fn http_client(&self) -> &ureq::Agent {
         &self.client
-    }
-
-    pub fn trust_oracle(&self, oracle_info: OracleInfo) -> anyhow::Result<()> {
-        self.bet_db.insert_oracle_info(oracle_info)
     }
 
     pub fn learn_outcome(
@@ -57,7 +53,7 @@ impl GunWallet {
         bet_id: BetId,
         attestation: Attestation<Secp256k1>,
     ) -> anyhow::Result<()> {
-        self.bet_db
+        self.db
             .update_bets(&[bet_id], move |old_state, _, txdb| match old_state {
                 BetState::Included { bet, .. } => {
                     let event_id = bet.oracle_event.event.id.clone();
@@ -267,7 +263,6 @@ impl GunWallet {
 
     // convenience methods
     pub fn sync(&self) -> anyhow::Result<()> {
-        eprintln!("syncing wallet...");
         self.wallet.sync(noop_progress(), None)?;
         Ok(())
     }

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -82,8 +82,14 @@ macro_rules! setup_test {
             },
         };
 
-        party_1.trust_oracle(oracle_info.clone()).unwrap();
-        party_2.trust_oracle(oracle_info.clone()).unwrap();
+        party_1
+            .gun_db()
+            .insert_entity(oracle_id.clone(), oracle_info.clone())
+            .unwrap();
+        party_2
+            .gun_db()
+            .insert_entity(oracle_id.clone(), oracle_info.clone())
+            .unwrap();
 
         let oracle_event = OracleEvent {
             event: Event {

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -1,16 +1,14 @@
 use anyhow::Context;
 use bdk::{
-    bitcoin::{Amount, Network},
-    blockchain::{
-        esplora::EsploraBlockchainConfig, noop_progress, AnyBlockchainConfig, Broadcast,
-        EsploraBlockchain,
-    },
-    database::BatchDatabase,
+    bitcoin::{util::bip32::ExtendedPrivKey, Amount, Network},
+    blockchain::{noop_progress, Broadcast, EsploraBlockchain},
     testutils::blockchain_tests::TestClient,
     wallet::AddressIndex,
     FeeRate, Wallet,
 };
-use gun_wallet::{betting::*, keychain::Keychain, FeeSpec, ValueChoice};
+use gun_wallet::{
+    betting::*, database::GunDatabase, keychain::Keychain, wallet::GunWallet, FeeSpec, ValueChoice,
+};
 use olivia_core::{
     announce, attest, AnnouncementSchemes, Attestation, AttestationSchemes, Event, EventId, Group,
     OracleEvent, OracleInfo, OracleKeys,
@@ -19,18 +17,19 @@ use olivia_secp256k1::{fun::Scalar, Secp256k1};
 use rand::Rng;
 use std::{str::FromStr, time::Duration};
 
-fn create_party(
-    test_client: &mut TestClient,
-    id: u8,
-) -> anyhow::Result<Party<EsploraBlockchain, impl BatchDatabase>> {
+fn create_party(test_client: &mut TestClient, id: u8) -> anyhow::Result<(GunWallet, Keychain)> {
     let mut r = [0u8; 64];
     rand::thread_rng().fill(&mut r);
     let keychain = Keychain::new(r);
-    let descriptor = bdk::template::Bip84(
-        keychain.main_wallet_xprv(Network::Regtest),
-        bdk::KeychainKind::External,
-    );
-    let db = bdk::database::MemoryDatabase::new();
+    let xprv = ExtendedPrivKey::new_master(Network::Regtest, &r).unwrap();
+    let descriptor = bdk::template::Bip84(xprv, bdk::KeychainKind::External);
+    let db = bdk::sled::Config::new()
+        .temporary(true)
+        .flush_every_ms(None)
+        .open()
+        .unwrap()
+        .open_tree("test")
+        .unwrap();
     let esplora_url = format!(
         "http://{}",
         test_client.electrsd.esplora_url.as_ref().unwrap()
@@ -43,7 +42,7 @@ fn create_party(
         .sync(noop_progress(), None)
         .context("syncing wallet failed")?;
 
-    let bet_db = BetDatabase::test_new();
+    let gun_db = GunDatabase::test_new();
 
     let funding_address = wallet.get_address(AddressIndex::New).unwrap().address;
 
@@ -56,20 +55,15 @@ fn create_party(
         println!("syncing done on party {} -- checking balance", id);
     }
 
-    let party = Party::new(
-        wallet,
-        bet_db,
-        keychain,
-        AnyBlockchainConfig::Esplora(EsploraBlockchainConfig::new(esplora_url, 2)),
-    );
-    Ok(party)
+    let wallet = GunWallet::new(wallet, gun_db);
+    Ok((wallet, keychain))
 }
 
 macro_rules! setup_test {
     () => {{
         let mut test_client = TestClient::default();
-        let party_1 = create_party(&mut test_client, 1).unwrap();
-        let party_2 = create_party(&mut test_client, 2).unwrap();
+        let (party_1, keychain_1) = create_party(&mut test_client, 1).unwrap();
+        let (party_2, keychain_2) = create_party(&mut test_client, 2).unwrap();
         let nonce_secret_key = Scalar::random(&mut rand::thread_rng());
         let announce_keypair =
             olivia_secp256k1::SCHNORR.new_keypair(Scalar::random(&mut rand::thread_rng()));
@@ -105,8 +99,8 @@ macro_rules! setup_test {
         };
         (
             test_client,
-            party_1,
-            party_2,
+            (party_1, keychain_1),
+            (party_2, keychain_2),
             oracle_info,
             attest_keypair,
             oracle_nonce_keypair,
@@ -122,7 +116,7 @@ macro_rules! wait_for_state {
         let mut cur_state;
         while {
             cur_state = $party
-                .bet_db()
+                .gun_db()
                 .get_entity::<BetState>($bet_id)
                 .unwrap()
                 .unwrap();
@@ -149,8 +143,8 @@ macro_rules! wait_for_state {
 pub fn test_happy_path() {
     let (
         mut test_client,
-        party_1,
-        party_2,
+        (party_1, keychain_1),
+        (party_2, keychain_2),
         oracle_info,
         attest_keypair,
         oracle_nonce_keypair,
@@ -166,12 +160,13 @@ pub fn test_happy_path() {
                 value: ValueChoice::Amount(Amount::from_str_with_denomination("0.01 BTC").unwrap()),
                 ..Default::default()
             },
+            &keychain_1,
         )
         .unwrap();
 
     let proposal_string = local_proposal.proposal.clone().into_versioned().to_string();
     let p1_bet_id = party_1
-        .bet_db()
+        .gun_db()
         .insert_bet(BetState::Proposed { local_proposal })
         .unwrap();
 
@@ -190,6 +185,7 @@ pub fn test_happy_path() {
                     ..Default::default()
                 },
                 FeeSpec::default(),
+                &keychain_2,
             )
             .unwrap();
         party_2
@@ -198,20 +194,22 @@ pub fn test_happy_path() {
     };
     wait_for_state!(party_2, p2_bet_id, "offered");
 
-    let (decrypted_offer, offer_public_key, rng) =
-        party_1.decrypt_offer(p1_bet_id, encrypted_offer).unwrap();
+    let (decrypted_offer, offer_public_key, rng) = party_1
+        .decrypt_offer(p1_bet_id, encrypted_offer, &keychain_1)
+        .unwrap();
     let mut validated_offer = party_1
         .validate_offer(
             p1_bet_id,
             decrypted_offer.into_offer(),
             offer_public_key,
             rng,
+            &keychain_1,
         )
         .unwrap();
     party_1.sign_validated_offer(&mut validated_offer).unwrap();
 
     Broadcast::broadcast(
-        party_1.wallet().client(),
+        party_1.bdk_wallet().client(),
         validated_offer.bet.psbt.clone().extract_tx(),
     )
     .unwrap();
@@ -227,7 +225,7 @@ pub fn test_happy_path() {
         true => ("blue", 1, &party_2, p2_bet_id, party_1, p1_bet_id),
     };
 
-    let winner_initial_balance = winner.wallet().get_balance().unwrap();
+    let winner_initial_balance = winner.bdk_wallet().get_balance().unwrap();
 
     let attestation = Attestation {
         outcome: outcome.into(),
@@ -264,20 +262,28 @@ pub fn test_happy_path() {
 
     let winner_claim_tx = winner_claim_psbt.extract_tx();
 
-    winner.wallet().broadcast(&winner_claim_tx).unwrap();
+    winner.bdk_wallet().broadcast(&winner_claim_tx).unwrap();
     wait_for_state!(winner, winner_id, "claiming");
     test_client.generate(1, None);
     wait_for_state!(winner, winner_id, "claimed");
-    winner.wallet().sync(noop_progress(), None).unwrap();
+    winner.bdk_wallet().sync(noop_progress(), None).unwrap();
 
-    assert!(winner.wallet().get_balance().unwrap() > winner_initial_balance);
+    assert!(winner.bdk_wallet().get_balance().unwrap() > winner_initial_balance);
     wait_for_state!(winner, winner_id, "claimed");
 }
 
 #[test]
 pub fn cancel_proposal() {
-    let (mut test_client, party_1, party_2, oracle_info, _, _, oracle_id, oracle_event) =
-        setup_test!();
+    let (
+        mut test_client,
+        (party_1, keychain_1),
+        (party_2, keychain_2),
+        oracle_info,
+        _,
+        _,
+        oracle_id,
+        oracle_event,
+    ) = setup_test!();
 
     let local_proposal_1 = party_1
         .make_proposal(
@@ -287,6 +293,7 @@ pub fn cancel_proposal() {
                 value: ValueChoice::Amount(Amount::from_str_with_denomination("0.02 BTC").unwrap()),
                 ..Default::default()
             },
+            &keychain_1,
         )
         .unwrap();
 
@@ -297,7 +304,7 @@ pub fn cancel_proposal() {
         .to_string();
 
     let p1_bet_id = party_1
-        .bet_db()
+        .gun_db()
         .insert_bet(BetState::Proposed {
             local_proposal: local_proposal_1,
         })
@@ -312,11 +319,12 @@ pub fn cancel_proposal() {
                 must_overlap: &[p1_bet_id],
                 ..Default::default()
             },
+            &keychain_2,
         )
         .unwrap();
 
     let bet_id_overlap = party_1
-        .bet_db()
+        .gun_db()
         .insert_bet(BetState::Proposed {
             local_proposal: local_proposal_2,
         })
@@ -337,6 +345,7 @@ pub fn cancel_proposal() {
                     ..Default::default()
                 },
                 FeeSpec::default(),
+                &keychain_2,
             )
             .unwrap();
         party_2
@@ -349,7 +358,7 @@ pub fn cancel_proposal() {
         .unwrap()
         .expect("should be able to cancel");
     let tx = psbt.extract_tx();
-    Broadcast::broadcast(party_1.wallet().client(), tx).unwrap();
+    Broadcast::broadcast(party_1.bdk_wallet().client(), tx).unwrap();
     wait_for_state!(party_1, p1_bet_id, "canceling");
     test_client.generate(1, None);
     wait_for_state!(party_1, bet_id_overlap, "canceled");
@@ -359,8 +368,16 @@ pub fn cancel_proposal() {
 
 #[test]
 pub fn test_cancel_offer() {
-    let (mut test_client, party_1, party_2, oracle_info, _, _, oracle_id, oracle_event) =
-        setup_test!();
+    let (
+        mut test_client,
+        (party_1, keychain_1),
+        (party_2, keychain_2),
+        oracle_info,
+        _,
+        _,
+        oracle_id,
+        oracle_event,
+    ) = setup_test!();
 
     let local_proposal = party_1
         .make_proposal(
@@ -370,6 +387,7 @@ pub fn test_cancel_offer() {
                 value: ValueChoice::Amount(Amount::from_str_with_denomination("0.01 BTC").unwrap()),
                 ..Default::default()
             },
+            &keychain_1,
         )
         .unwrap();
 
@@ -390,6 +408,7 @@ pub fn test_cancel_offer() {
                     ..Default::default()
                 },
                 FeeSpec::default(),
+                &keychain_2,
             )
             .unwrap();
         party_2
@@ -402,7 +421,7 @@ pub fn test_cancel_offer() {
         .unwrap()
         .expect("should be able to cancel");
     let tx = psbt.extract_tx();
-    Broadcast::broadcast(party_2.wallet().client(), tx).unwrap();
+    Broadcast::broadcast(party_2.bdk_wallet().client(), tx).unwrap();
 
     wait_for_state!(party_2, p2_bet_id, "canceling");
     test_client.generate(1, None);
@@ -411,8 +430,16 @@ pub fn test_cancel_offer() {
 
 #[test]
 pub fn cancel_offer_after_offer_taken() {
-    let (mut test_client, party_1, party_2, oracle_info, _, _, oracle_id, oracle_event) =
-        setup_test!();
+    let (
+        mut test_client,
+        (party_1, keychain_1),
+        (party_2, keychain_2),
+        oracle_info,
+        _,
+        _,
+        oracle_id,
+        oracle_event,
+    ) = setup_test!();
 
     let local_proposal = party_1
         .make_proposal(
@@ -422,12 +449,13 @@ pub fn cancel_offer_after_offer_taken() {
                 value: ValueChoice::Amount(Amount::from_str_with_denomination("0.01 BTC").unwrap()),
                 ..Default::default()
             },
+            &keychain_1,
         )
         .unwrap();
 
     let proposal_str = local_proposal.proposal.clone().into_versioned().to_string();
     let p1_bet_id = party_1
-        .bet_db()
+        .gun_db()
         .insert_bet(BetState::Proposed { local_proposal })
         .unwrap();
     let proposal = Proposal::from(VersionedProposal::from_str(&proposal_str).unwrap());
@@ -446,6 +474,7 @@ pub fn cancel_offer_after_offer_taken() {
                     ..Default::default()
                 },
                 FeeSpec::default(),
+                &keychain_2,
             )
             .unwrap();
         party_2
@@ -468,6 +497,7 @@ pub fn cancel_offer_after_offer_taken() {
                     ..Default::default()
                 },
                 FeeSpec::Rate(FeeRate::from_sat_per_vb(1.0)),
+                &keychain_2,
             )
             .unwrap();
         party_2
@@ -476,7 +506,7 @@ pub fn cancel_offer_after_offer_taken() {
     };
 
     let (second_decrypted_offer, second_offer_public_key, rng) = party_1
-        .decrypt_offer(p1_bet_id, second_encrypted_offer)
+        .decrypt_offer(p1_bet_id, second_encrypted_offer, &keychain_1)
         .unwrap();
     let mut second_validated_offer = party_1
         .validate_offer(
@@ -484,13 +514,14 @@ pub fn cancel_offer_after_offer_taken() {
             second_decrypted_offer.into_offer(),
             second_offer_public_key,
             rng,
+            &keychain_1,
         )
         .unwrap();
     party_1
         .sign_validated_offer(&mut second_validated_offer)
         .unwrap();
 
-    Broadcast::broadcast(party_1.wallet().client(), second_validated_offer.tx()).unwrap();
+    Broadcast::broadcast(party_1.bdk_wallet().client(), second_validated_offer.tx()).unwrap();
     party_1.set_offer_taken(second_validated_offer).unwrap();
 
     wait_for_state!(party_1, p1_bet_id, "unconfirmed");
@@ -502,7 +533,7 @@ pub fn cancel_offer_after_offer_taken() {
         .unwrap()
         .expect("should be able to cancel");
     let tx = psbt.extract_tx();
-    Broadcast::broadcast(party_2.wallet().client(), tx).unwrap();
+    Broadcast::broadcast(party_2.bdk_wallet().client(), tx).unwrap();
 
     wait_for_state!(party_2, second_p2_bet_id, "canceling");
     wait_for_state!(party_2, first_p2_bet_id, "canceling");
@@ -513,10 +544,18 @@ pub fn cancel_offer_after_offer_taken() {
 
 #[test]
 fn create_proposal_with_dust_change() {
-    let (mut test_client, party_1, party_2, oracle_info, _, _, oracle_id, oracle_event) =
-        setup_test!();
+    let (
+        mut test_client,
+        (party_1, keychain_1),
+        (party_2, keychain_2),
+        oracle_info,
+        _,
+        _,
+        oracle_id,
+        oracle_event,
+    ) = setup_test!();
 
-    let balance = party_1.wallet().get_balance().unwrap();
+    let balance = party_1.bdk_wallet().get_balance().unwrap();
     let bet_value = balance - 250;
 
     let local_proposal = party_1
@@ -527,6 +566,7 @@ fn create_proposal_with_dust_change() {
                 value: ValueChoice::Amount(Amount::from_sat(bet_value)),
                 ..Default::default()
             },
+            &keychain_1,
         )
         .unwrap();
 
@@ -534,14 +574,14 @@ fn create_proposal_with_dust_change() {
     assert_eq!(local_proposal.proposal.value.as_sat(), bet_value);
 
     let p1_bet_id = party_1
-        .bet_db()
+        .gun_db()
         .insert_bet(BetState::Proposed {
             local_proposal: local_proposal.clone(),
         })
         .unwrap();
 
     let (p2_bet_id, encrypted_offer) = {
-        let balance = party_2.wallet().get_balance().unwrap();
+        let balance = party_2.bdk_wallet().get_balance().unwrap();
         let bet_value = balance - 250;
 
         assert!(
@@ -557,6 +597,7 @@ fn create_proposal_with_dust_change() {
                             ..Default::default()
                         },
                         FeeSpec::Absolute(Amount::from_sat(501)),
+                        &keychain_2
                     )
                     .map(|_| ())
                     .unwrap_err()
@@ -579,6 +620,7 @@ fn create_proposal_with_dust_change() {
                 },
                 // we can afford 500
                 FeeSpec::Absolute(Amount::from_sat(500)),
+                &keychain_2,
             )
             .unwrap();
 
@@ -594,20 +636,22 @@ fn create_proposal_with_dust_change() {
 
     wait_for_state!(party_2, p2_bet_id, "offered");
 
-    let (decrypted_offer, offer_public_key, rng) =
-        party_1.decrypt_offer(p1_bet_id, encrypted_offer).unwrap();
+    let (decrypted_offer, offer_public_key, rng) = party_1
+        .decrypt_offer(p1_bet_id, encrypted_offer, &keychain_1)
+        .unwrap();
     let mut validated_offer = party_1
         .validate_offer(
             p1_bet_id,
             decrypted_offer.into_offer(),
             offer_public_key,
             rng,
+            &keychain_1,
         )
         .unwrap();
     party_1.sign_validated_offer(&mut validated_offer).unwrap();
 
     Broadcast::broadcast(
-        party_1.wallet().client(),
+        party_1.bdk_wallet().client(),
         validated_offer.bet.psbt.clone().extract_tx(),
     )
     .unwrap();


### PR DESCRIPTION
1. Store the randomness in the database instead
2. Make it optional
3. Remove support for old configs for simplicity
4. and require re-initialisation to upgrade wallet

I thought it wasn't yet worth it to introduce a proper upgrade function. Now that v0.6 no longer simply involves changes to the config I trashed the backwards compatible config reading. You need to gun init seedwords --from-existing to upgrade