### PR TITLE
Remove ability to configure seed words path

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -174,15 +174,14 @@ pub fn load_wallet(
                 config.network,
             )),
             GunSigner::SeedWordsFile {
-                file_path,
                 passphrase_fingerprint,
             } => {
-                let seed_words =
-                    fs::read_to_string(file_path.clone()).context("loading seed words")?;
+                let file_path = wallet_dir.join("seed.txt");
+                let seed_words = fs::read_to_string(&file_path).context("loading seed words")?;
                 let mnemonic = Mnemonic::parse(&seed_words).map_err(|e| {
                     anyhow!(
                         "parsing seed phrase in '{}' failed: {}",
-                        file_path.as_path().display(),
+                        file_path.display(),
                         e
                     )
                 })?;

--- a/src/cmd/setup.rs
+++ b/src/cmd/setup.rs
@@ -210,7 +210,6 @@ pub fn run_setup(wallet_dir: &std::path::Path, cmd: SetupOpt) -> anyhow::Result<
             let master_fingerprint = xpriv.fingerprint(&secp);
 
             let signers = vec![GunSigner::SeedWordsFile {
-                file_path: sw_file.clone(),
                 passphrase_fingerprint: if use_passphrase {
                     Some(master_fingerprint)
                 } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,6 @@ pub enum WalletKeyOld {
 #[serde(rename_all = "kebab-case", tag = "kind")]
 pub enum GunSigner {
     SeedWordsFile {
-        file_path: PathBuf,
         #[serde(skip_serializing_if = "Option::is_none")]
         passphrase_fingerprint: Option<Fingerprint>,
     },


### PR DESCRIPTION
This is dangerous since if you move your directory and then setup a new
one there the moved gun directory config will used the seed words from
the other wallet.

We can add it back if we need it.